### PR TITLE
Allows setting the random seed to use when benchmarking or testing.

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <time.h>
 #include "utils.h"
 
 #define RUN_COMMAND "run"
@@ -35,7 +36,7 @@ typedef struct run_command_opts
     int pattern_min_len, pattern_max_len;
     int num_runs;
     int time_limit_millis;
-
+    int random_seed;
     // flags
 
     int simple,
@@ -89,6 +90,7 @@ void print_run_usage_and_exit(const char *command)
     printf("\t              Use option \"all\" to performe experimental results using all text buffers.\n");
     printf("\t              Use the style A-B-C to performe experimental results using multiple text buffers.\n");
     printf("\t              Separate the list of text buffers using the symbol \"-\"\n");
+    printf("\t-seed S       Sets the random seed to integer S, ensuring tests and benchmarks can be precisely repeated.\n");
     printf("\t-short        computes experimental results using short length patterns (from 2 to 32)\n");
     printf("\t-vshort       computes experimental results using very short length patterns (from 1 to 16)\n");
     printf("\t-occ          prints the average number of occurrences\n");
@@ -123,6 +125,7 @@ void opts_init_default(run_command_opts_t *opts)
     opts->alphabet_size = -1;
     opts->num_runs = NUM_RUNS_DEFAULT;
     opts->time_limit_millis = TIME_LIMIT_MILLIS_DEFAULT;
+    opts->random_seed = time(NULL);
     opts->simple = 0;
     opts->occ = 0;
     opts->txt = 0;
@@ -205,6 +208,16 @@ int parse_pattern_len(run_command_opts_t *line, int curr_arg, int argc, const ch
         print_error_and_exit();
 
     return 2;
+}
+
+int parse_seed(run_command_opts_t *line, int curr_arg, int argc, const char **argv)
+{
+    if (curr_arg + 1 >= argc)
+        print_error_and_exit();
+
+    line->random_seed = atoi(argv[curr_arg + 1]);
+
+    return 1;
 }
 
 int parse_simple(run_command_opts_t *line, int curr_arg, int argc, const char **argv)
@@ -296,6 +309,10 @@ void parse_run_args(int argc, const char **argv, smart_subcommand_t *subcommand)
         else if (!strcmp("-plen", argv[curr_arg]))
         {
             curr_arg += parse_pattern_len(opts, curr_arg, argc, argv);
+        }
+        else if (!strcmp("-seed", argv[curr_arg]))
+        {
+            curr_arg += parse_seed(opts, curr_arg, argc, argv);
         }
         else if (!strcmp("-simple", argv[curr_arg]))
         {

--- a/src/run.h
+++ b/src/run.h
@@ -409,9 +409,10 @@ void run_benchmarks(run_command_opts_t *opts, unsigned char *T)
 
 int exec_run(run_command_opts_t *opts)
 {
-    srand(time(NULL));
-
     print_logo();
+
+    srand(opts->random_seed);
+    printf("\n\tSetting random seed for this benchmarking run to %d\n", opts->random_seed);
 
     unsigned char *T = (unsigned char *)malloc(sizeof(unsigned char) * (opts->text_size + PATTERN_SIZE_MAX));
 


### PR DESCRIPTION
  * Defaults to using time(NULL) as before.
  * Always reports the seed used, even if you haven't set it.
  * Adds a -seed {S} parameter that lets you set the seed to an integer.

Will close issue #1 