### PR TITLE
Fix segfault in simon.

### DIFF
--- a/src/algos/simon.c
+++ b/src/algos/simon.c
@@ -59,7 +59,7 @@ int preSimon(unsigned char *x, int m, List L[]) {
    int i, k, ell;
    List cell;
  
-   memset(L, 0, (m - 2)*sizeof(List));
+   memset(L, 0, (m - 1)*sizeof(List));
    ell = -1;
    for (i = 1; i < m; ++i) {
       k = ell;


### PR DESCRIPTION
  * presimon tried to memset to zero a list of size m-2 * sizeof(List).
  * When m = 1, this gave a negative size to give to malloc.
  * fix is to zero out m - 1, not m - 2.