### PR TITLE
Max array size was lower than the hash function returned.

### DIFF
--- a/src/algos/skip2.c
+++ b/src/algos/skip2.c
@@ -21,7 +21,7 @@
 #include "include/main.h"
 #include "include/AUTOMATON.h"
 
-#define DSIGMA 1024
+#define DSIGMA 1280 // max index given HS = 255 + (255 * 4) = 1275
 #define HS(x,i) (x[i]<<2) + x[i+1]
 #define Q 2
 

--- a/src/algos/skip4.c
+++ b/src/algos/skip4.c
@@ -21,7 +21,7 @@
 #include "include/main.h"
 #include "include/AUTOMATON.h"
 
-#define DSIGMA 16380
+#define DSIGMA 21700 // max index given HS = 255 + (255 * 4) + (255 * 16) + (255 * 64) = 21675
 #define HS(x,i) (x[i]<<6) + (x[i+1]<<4) +  (x[i+2]<<2) + x[i+3]
 #define Q 4
 


### PR DESCRIPTION
  * could return a hash value index that was greater than the size of the hash table.
  * fix is to increase size of hash table so it is bigger than the maximum index the hash function can provide.