### PR TITLE
Fix memory leak and allow any size pattern.

### DIFF
--- a/src/algos/blim.c
+++ b/src/algos/blim.c
@@ -25,16 +25,15 @@
 
 #include "include/define.h"
 #include "include/main.h"
-#define MAXWSIZE (XSIZE + WORD)
 
 int search(unsigned char* x, int m, unsigned char* y, int n)
 {
    int i,j,k,count;
    unsigned int   wsize = WORD - 1 + m;
-   unsigned long* M = (unsigned long*)malloc(sizeof(unsigned long)*SIGMA * MAXWSIZE);
+   unsigned long* M = (unsigned long*)malloc(sizeof(unsigned long)*SIGMA * (m + WORD));
    unsigned long  tmp, F;
-   unsigned int   ScanOrder[XSIZE];
-   unsigned int   MScanOrder[XSIZE];
+   unsigned int   ScanOrder[wsize];
+   unsigned int   MScanOrder[wsize];
    unsigned int*  so  = ScanOrder;
    unsigned int*  mso = MScanOrder;
    unsigned int   shift[SIGMA];
@@ -82,6 +81,7 @@ int search(unsigned char* x, int m, unsigned char* y, int n)
       i+=shift[y[i+wsize]];
       F = M[MScanOrder[0]+y[i+ScanOrder[0]]] & M[MScanOrder[1]+y[i+ScanOrder[1]]];
    }
+   free(M);
    END_SEARCHING
    return count;
 }


### PR DESCRIPTION
 * M malloc wasn't being freed at end.
 * Allocated up to a max of 4200 pattern size, but we don't have those limits in new smart.  Allocate buffers appropriate to the actual size of the pattern and word length.

I originally thought blim had an infinite loop as it was so slow.  In reality, it really is very slow.  However, it did crash smart by never freeing large quantities of memory that just built up on repeated test runs.