### PR TITLE
Fix BSDM algos.

### DIFF
--- a/src/algos/bsdm2.c
+++ b/src/algos/bsdm2.c
@@ -25,14 +25,12 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 65536
+#define DSIGMA 2048 // Max returned by HS = 255 + (255*4) = 1275
 #define HS(x,i) (x[i]<<2) + x[i+1]
 #define Q 2
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
-    unsigned int s,d;
     if(m<Q) return -1;
     
     BEGIN_PREPROCESSING

--- a/src/algos/bsdm3.c
+++ b/src/algos/bsdm3.c
@@ -25,12 +25,11 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 65536
+#define DSIGMA 8192 // max returned by HS = 255 + (255*4) + (255*16) = 5355
 #define HS(x,i) (x[i]<<4) + (x[i+1]<<2) +  x[i+2]
 #define Q 3
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
     unsigned int s,d;
 	if(m<Q) return -1;

--- a/src/algos/bsdm4.c
+++ b/src/algos/bsdm4.c
@@ -25,12 +25,11 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 65536
+#define DSIGMA 32768  // max returned by HS = 255 + (255*4) + (255*16) + (255*64) = 21675
 #define HS(x,i) (x[i]<<6) + (x[i+1]<<4) +  (x[i+2]<<2) + x[i+3]
 #define Q 4
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
     unsigned int s,d;
 	if(m<Q) return -1;

--- a/src/algos/bsdm5.c
+++ b/src/algos/bsdm5.c
@@ -25,12 +25,11 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 65536
+#define DSIGMA 8192 // Max returned by HS = 255+(255×2)+(255×4)+(255×8)+(255×16) = 7905
 #define HS(x,i) (x[i]<<4) + (x[i+1]<<3) +  (x[i+2]<<2) + (x[i+3]<<1) + x[i+4]
 #define Q 5
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
     unsigned int s,d;
 	if(m<Q) return -1;

--- a/src/algos/bsdm6.c
+++ b/src/algos/bsdm6.c
@@ -25,12 +25,11 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 8192
+#define DSIGMA 16384 // Max returned by HS = 255+(255×2)+(255×4)+(255×8)+(255×16)+(255×32) = 16065
 #define HS(x,i) (x[i]<<5) + (x[i+1]<<4) +  (x[i+2]<<3) + (x[i+3]<<2) + (x[i+4]<<1) + x[i+5]
 #define Q 6
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
     unsigned int s,d;
 	if(m<Q) return -1;
@@ -71,7 +70,8 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	for(i=0; i<m; i++) y[n+i]=x[i];
 	unsigned char *xst = x+st;
 	int offset = len+st-1;
-	j = len-1;
+
+    j = len-1;
 	while(j<n) {
 	    c = HS(y,j);
 	    while ((i=pos[c])<0) {

--- a/src/algos/bsdm7.c
+++ b/src/algos/bsdm7.c
@@ -25,12 +25,11 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 65536
+#define DSIGMA 32768 // Max returned by HS = 255+(255×2)+(255×4)+(255×8)+(255×16)+(255×32)+(255×64) = 32385
 #define HS(x,i) (x[i]<<6) + (x[i+1]<<5) +  (x[i+2]<<4) + (x[i+3]<<3) + (x[i+4]<<2) + (x[i+5]<<1) + x[i+6]
 #define Q 7
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
     unsigned int s,d;
 	if(m<Q) return -1;

--- a/src/algos/bsdm8.c
+++ b/src/algos/bsdm8.c
@@ -25,12 +25,11 @@
 #include "include/define.h"
 #include "include/main.h"
 
-#define DSIGMA 65536
+#define DSIGMA 65536 // Max returned by HS = 255+(255×2)+(255×4)+(255×8)+(255×16)+(255×32)+(255×64)+(256*128) = 65153
 #define HS(x,i) (x[i]<<7) + (x[i+1]<<6) +  (x[i+2]<<5) + (x[i+3]<<4) + (x[i+4]<<3) + (x[i+5]<<2) + (x[i+6]<<1) + x[i+7]
 #define Q 8
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-	unsigned int B[DSIGMA];
 	int i, j, k, count;
     unsigned int s,d;
 	if(m<Q) return -1;


### PR DESCRIPTION
 * BSDM6 was allocating too small a buffer, overwriting memory and causing an infinite loop when it randomly set len to zero.
 * All the other algorithms are allocating too much memory on average.  The max it needs for DSIGMA is the largest value returned by the HS hash function.
 * Remove unused variable B and a couple of others from the code.