### PR TITLE
Add algos to run directly

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -9,6 +9,12 @@
 #define MEGA_BYTE (1024 * 1024)           // constant for 1 MB size
 
 /*
+ * Search return codes
+ */
+#define INFO_CANNOT_SEARCH (-1)           // return code for algorithms that cannot search for a given pattern in a text.
+#define ERROR_SEARCHING (-2)              // return code for algorithms that encounter an error while pre-processing or searching.
+
+/*
  * Limits.
  */
 #define MAX_PATH_LENGTH 2048              // Maximum file path length.

--- a/src/utils.h
+++ b/src/utils.h
@@ -372,16 +372,6 @@ void set_time_string(char *time_string, int size, const char * time_format)
 }
 
 /*
- * Prints a message followed by the time.
- */
-void print_time_message(const char *message)
-{
-    char time_format[26];
-    set_time_string(time_format, 26, "%Y:%m:%d %H:%M:%S");
-    info("%s %s", message, time_format);
-}
-
-/*
  * Prints a name and value pair aligned to a column width followed by a newline.
  */
 void print_name_value(const char *name, const char *value, int column_width)


### PR DESCRIPTION
Adds the ability to run algos directly from the run command, like the test command.

`smart run hor wfr.* -text genome`
`smart run -all -text genome`
`smart run -use "my-fast-algos" -text genome`
`smart run hor wfr -use "my-fast-algos" -text genome`

Also adds in support for a return code for errors searching (-2) in addition to the cannot search return code (-1).