### PR TITLE
Fix algos to allow any size pattern.

### DIFF
--- a/src/algos/ac.c
+++ b/src/algos/ac.c
@@ -40,9 +40,8 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
    }
 }
 
-
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, k, ell, kmpNext[XSIZE], count;
+    int i, j, k, ell, kmpNext[m], count;
 
     /* Preprocessing */
     BEGIN_PREPROCESSING

--- a/src/algos/ag.c
+++ b/src/algos/ag.c
@@ -29,8 +29,7 @@ void preBmBc(unsigned char *x, int m, int bmBc[]) {
     for (i = 0; i < SIGMA; ++i) bmBc[i] = m;
     for (i = 0; i < m - 1; ++i) bmBc[x[i]] = m - i - 1;
 }
- 
- 
+
 void suffixes(unsigned char *x, int m, int *suff) {
     int f, g, i;
     suff[m - 1] = m;
@@ -61,11 +60,9 @@ void preBmGsAG(unsigned char *x, int m, int bmGs[], int suff[]) {
         bmGs[m - 1 - suff[i]] = m - 1 - i;
 }
 
-
-
 int search(unsigned char *x, int m, unsigned char *y, int n) {
     int i, j, k, s, shift, count;
-    int bmGs[XSIZE], skip[XSIZE], suff[XSIZE], bmBc[SIGMA];
+    int bmGs[m], skip[m], suff[m], bmBc[SIGMA];
   
     /* Preprocessing */
     BEGIN_PREPROCESSING

--- a/src/algos/aoso2.c
+++ b/src/algos/aoso2.c
@@ -39,6 +39,9 @@ void verify(unsigned char *y, int j, int n, unsigned char *x, int m, int q, unsi
     }
 }
 
+// Forward declaration.
+int search_large(unsigned char *x, int m, unsigned char *y, int n, int q);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
     unsigned int B[SIGMA], D, h, mm, tmp, not_mm;
     int i, j, count;

--- a/src/algos/aoso4.c
+++ b/src/algos/aoso4.c
@@ -39,6 +39,9 @@ void verify(unsigned char *y, int j, int n, unsigned char *x, int m, int q, unsi
     }
 }
 
+// Forward declaration:
+int search_large(unsigned char *x, int m, unsigned char *y, int n, int q);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
     unsigned int B[SIGMA], D, h, mm, tmp, not_mm;
     int i, j, count;

--- a/src/algos/aoso6.c
+++ b/src/algos/aoso6.c
@@ -39,6 +39,9 @@ void verify(unsigned char *y, int j, int n, unsigned char *x, int m, int q, unsi
     }
 }
 
+// Forward declaration:
+int search_large(unsigned char *x, int m, unsigned char *y, int n, int q);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
     unsigned int B[SIGMA], D, h, mm, tmp, not_mm;
     int i, j, count;

--- a/src/algos/askip.c
+++ b/src/algos/askip.c
@@ -159,10 +159,10 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
                   free(automaton->trans);
                   free(automaton->term);
                   free(automaton->fail);
-                  free(automaton);
                   for (i = automaton->root; i < automaton->nodeCounter; ++i)
                      freeListOfIntegers(z[i]);
-                  free(z);
+                   free(automaton);
+                   free(z);
                   END_SEARCHING
                   return count;
                }

--- a/src/algos/bfs.c
+++ b/src/algos/bfs.c
@@ -25,8 +25,16 @@
 #include "include/define.h"
 #include "include/main.h"
 
-void PreBFS(unsigned char *x, int m, int bm_gs[XSIZE][SIGMA]) {
-   int i, j, p, c, h, last, suffix_len, temp[XSIZE];
+/*
+ * Issues
+ * ------
+ * - cannot process large patterns because table gs is allocated on stack, and is m * SIGMA.
+ * - for now, just return -1 if pattern size is greater than 4096.
+ * - Proper fix is to allocate this memory dynamically on heap.
+ */
+
+void PreBFS(unsigned char *x, int m, int bm_gs[][SIGMA]) {
+   int i, j, p, c, h, last, suffix_len, temp[m + 1];
    suffix_len = 1;
    last = m-1;
    for(i=0;i<=m;i++) for(j=0; j<SIGMA;j++) bm_gs[i][j] = m;
@@ -63,7 +71,10 @@ void PreBFS(unsigned char *x, int m, int bm_gs[XSIZE][SIGMA]) {
 
 int search(unsigned char *x, int m, unsigned char *y, int n)
 {
-   int i, j, k, s, count, gs[XSIZE][SIGMA], bc[SIGMA];
+    if (m > 4096)
+        return -1; // cannot allocate gs table when m is large = m * SIGMA.
+
+    int i, j, k, s, count, gs[m + 1][SIGMA], bc[SIGMA];
    int *last, first;
    char ch = x[m-1];
 

--- a/src/algos/bm.c
+++ b/src/algos/bm.c
@@ -31,8 +31,7 @@ void preBmBc(unsigned char *x, int m, int bmBc[]) {
    for (i = 0; i < m - 1; ++i)
       bmBc[x[i]] = m - i - 1;
 }
- 
- 
+
 void suffixes(unsigned char *x, int m, int *suff) {
    int f, g, i;
    suff[m - 1] = m;
@@ -52,7 +51,7 @@ void suffixes(unsigned char *x, int m, int *suff) {
 }
  
 void preBmGs(unsigned char *x, int m, int bmGs[]) {
-   int i, j, suff[XSIZE];
+   int i, j, suff[m];
    suffixes(x, m, suff);
    for (i = 0; i < m; ++i) bmGs[i] = m;
    j = 0;
@@ -64,10 +63,9 @@ void preBmGs(unsigned char *x, int m, int bmGs[]) {
    for (i = 0; i <= m - 2; ++i)
       bmGs[m - 1 - suff[i]] = m - 1 - i;
 }
- 
- 
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, bmGs[XSIZE], bmBc[SIGMA], count;
+   int i, j, bmGs[m], bmBc[SIGMA], count;
  
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/bom.c
+++ b/src/algos/bom.c
@@ -52,7 +52,7 @@ void setTransition(int p, int q, List L[]) {
 
 void oracle(unsigned char *x, int m, char T[], List L[]) {
    int i, p, q;
-   int S[XSIZE + 1];
+   int S[m + 1];
    char c;
    S[m] = m + 1;
    for (i = m; i > 0; --i) {
@@ -75,8 +75,8 @@ void oracle(unsigned char *x, int m, char T[], List L[]) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   char T[XSIZE + 1];
-   List L[XSIZE + 1];
+   char T[m + 1];
+   List L[m + 1];
    int i, j, r, period, q, shift, count;
 
 	BEGIN_PREPROCESSING

--- a/src/algos/bom2.c
+++ b/src/algos/bom2.c
@@ -26,8 +26,8 @@
 #include "include/main.h"
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int S[XSIZE];
-   int *trans[XSIZE];
+   int S[m + 2];
+   int *trans[m + 2];
    int i, j, p, q;
    int iMinus1, mMinus1, nMinusm, count;
 

--- a/src/algos/ebom.c
+++ b/src/algos/ebom.c
@@ -26,8 +26,8 @@
 #include "include/main.h"
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int S[XSIZE], FT[SIGMA][SIGMA];
-   int *trans[XSIZE];
+   int S[m + 2], FT[SIGMA][SIGMA];
+   int *trans[m + 2];
    int i, j, p, q;
    int iMinus1, mMinus1, count;
    unsigned char c;

--- a/src/algos/fbom.c
+++ b/src/algos/fbom.c
@@ -26,8 +26,8 @@
 #include "include/main.h"
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int S[XSIZE], FT[SIGMA][SIGMA];
-   int *trans[XSIZE];
+   int S[m + 2], FT[SIGMA][SIGMA];
+   int *trans[m + 2];
    int i, j, p, q;
    int iMinus1, mMinus1, count;
    unsigned char c;

--- a/src/algos/ffs.c
+++ b/src/algos/ffs.c
@@ -25,32 +25,53 @@
 #include "include/define.h"
 #include "include/main.h"
 
-void Forward_Suffix_Function(unsigned char *x, int m, int bm_gs[XSIZE][SIGMA], int alpha) {
+/*
+ * Issues
+ * ======
+ *  - memory allocation failure when m > 4096, too much memory for gs[m][SIGMA] on stack.
+ *
+ *  Memory allocation failure
+ *  -------------------------
+ *  Allocating the table gx[m][SIGMA] creates 256 elements for each pattern position.  When m > 4096, this
+ *  tries to allocate too much memory on the stack, and we get a seg fault.  The proper fix is to allocate
+ *  the memory for this table dynamically instead of on the stack.  For now, just return -1 if m > 4096.
+ */
+
+void Forward_Suffix_Function(unsigned char *x, int m, int bm_gs[][SIGMA], int alpha) {
    int init;
-   int i, j, last, suffix_len, temx[XSIZE];
+   int i, j, last, suffix_len, temx[m + 1];
    init = 0;
-   for(i=0;i<m;i++) for(j=init; j<init+alpha;j++) bm_gs[i][j] = m+1;
-   for(i=0; i<m; i++) temx[i]=i-1;
-   for(suffix_len=0; suffix_len<=m; suffix_len++) {
-      last = m-1;
-      i = temx[last];
-      while(i>=0) {
-         if( bm_gs[m-suffix_len][x[i+1]]>m-1-i )
-            if(i-suffix_len<0 || (i-suffix_len>=0 && x[i-suffix_len]!=x[m-1-suffix_len]))
-               bm_gs[m-suffix_len][x[i+1]]=m-1-i;
-         if((i-suffix_len >= 0 && x[i-suffix_len]==x[last-suffix_len]) || (i-suffix_len <  0)) {
-            temx[last]=i;
-            last=i;
+   for(i=0;i<m;i++) for(j=init; j<init+alpha;j++) bm_gs[i][j] = m+1;  // WARN: allocates within bounds of m but sets values of m + 1.
+   for(i=0; i<m; i++) temx[i]=i-1;                                    // PROBABLY OK: only allocates within bounds of m, contains [-1 .. m - 2] (assuming we don't use the -1).
+   for(suffix_len=0; suffix_len<=m; suffix_len++) {                   // WARN: suffix_len <= m, instead of < m - will go to m + 1 elements.
+      last = m-1;                                                     // SAFE: within m
+      i = temx[last];                                                 // SAFE: only references within m, except where it is -1.
+      while(i>=0) {                                                   // SAFE: Don't use the -1 element
+         if( bm_gs[m-suffix_len][x[i+1]]>m-1-i )                      // WARN: will reference element m + 1 of bm_gs (at position m) when suffix_len == 0.
+            if(i-suffix_len<0 || (i-suffix_len>=0 && x[i-suffix_len]!=x[m-1-suffix_len]))  // ASSUME: code does not buffer overflow on pattern buffer, but its own pre-processing tables.
+               bm_gs[m-suffix_len][x[i+1]]=m-1-i;                     // WARN: will reference element m + 1 of bm_gs (at position m) when suffix_len == 0.
+         if((i-suffix_len >= 0 && x[i-suffix_len]==x[last-suffix_len]) || (i-suffix_len <  0)) { // ASSUME: code does not buffer overflow on pattern buffer, but its own pre-processing tables.
+            temx[last]=i;                                             // SAFE: temx only contains values from [-1 .. m - 2], i is set from temx.
+            last=i;                                                   // SAFE: last, i and temx[] can only contain values from [-1 .. m - 2]
          }
-         i = temx[i];
+         i = temx[i];                                                 // SAFE: last, i and temx[] can only contain values from [-1 .. m - 2]
       }
-      if(bm_gs[m-suffix_len][x[0]] > m) bm_gs[m-suffix_len][x[0]] = m;
+      if(bm_gs[m-suffix_len][x[0]] > m) bm_gs[m-suffix_len][x[0]] = m; // WARN: can access element m + 1 at position m when suffix_len == 0
       temx[last]=-1;
    }
 }
 
+//WARN: cannot allocate a large gs array here.  When m gets too big, gs[m][SIGMA} becomes very large.
+//      The practical limit seems to be 4096 for m.
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, k, s, count, gs[XSIZE][SIGMA], bc[SIGMA];
+   // any pattern greater than this cannot be searched by this implementation, as it tries to allocate too much memory to gs[][].
+   // Would need to allocate the gs memory dynamically with malloc to search longer patterns.
+   // This heuristic limit of 4096 may be system-dependent.
+   if (m > 4096)
+        return -1;
+
+   int i, j, k, s, count, gs[m + 1][SIGMA], bc[SIGMA];
    char ch = x[m-1];
 
    /* Preprocessing */
@@ -58,8 +79,8 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
    Forward_Suffix_Function(x, m, gs, SIGMA);
    for (i=0; i < SIGMA; i++) bc[i]=m;
    for (j=0; j < m; j++) bc[x[j]]=m-j-1;
-   for(i=0; i<=m; i++) y[n+i]=ch;
-   y[n+m+1]='\0';
+   for(i=0; i<=m; i++) y[n+i]=ch;                                      //NOTE: text modification - writes one more than the pattern buffer length to the end of the text.
+   y[n+m+1]='\0';                                                      //NOTE: text modification - write a null terminator at n + m + 1 to the end of the text.
    END_PREPROCESSING
 
    /* Searching */

--- a/src/algos/fjs.c
+++ b/src/algos/fjs.c
@@ -47,7 +47,7 @@ void preKmp(unsigned char *x, int m, int kmpNexy[]) {
 }
 
 int search( unsigned char *x, int m, unsigned char *y, int n ) {
-   int i, s, count, qsbc[SIGMA], kmp[XSIZE];
+   int i, s, count, qsbc[SIGMA], kmp[m];
 
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/fs-w1.c
+++ b/src/algos/fs-w1.c
@@ -45,8 +45,8 @@
 #include "include/main.h"
 
 void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
-   int i, j, p, f[XSIZE];
-   for(i=0;i<XSIZE;i++) bm_gs[i]=0;
+   int i, j, p, f[m + 1];
+   for(i=0;i<m + 1;i++) bm_gs[i]=0;
    f[m]=j=m+1;
    for (i=m; i > 0; i--) {
       while (j <= m && x[i-1] != x[j-1]) {
@@ -64,8 +64,8 @@ void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
 
 int search(unsigned char *P, int m, unsigned char *T, int n)
 {
-   int i,j,s1,s2,k,h,count,hbcr[SIGMA],hbcl[SIGMA],gsR[XSIZE],gsL[XSIZE];
-   unsigned char c,Pr[XSIZE],P2[XSIZE];
+   int i,j,s1,k,h,count,hbcr[SIGMA],hbcl[SIGMA],gsR[m + 1],gsL[m + 1];
+   unsigned char Pr[m + 1];
 
    /* prprocessing */
    BEGIN_PREPROCESSING
@@ -79,7 +79,6 @@ int search(unsigned char *P, int m, unsigned char *T, int n)
 	Pre_GS(P,  m, gsR);
 	Pre_GS(Pr, m, gsL);
    
-   unsigned char lastch = P[m-1], firstch=P[0];
 	for(i=0; i<m; i++) T[n+i]=P[i];
    int mm1 = m-1;
    END_PREPROCESSING

--- a/src/algos/fs-w2.c
+++ b/src/algos/fs-w2.c
@@ -45,8 +45,8 @@
 #include "include/main.h"
 
 void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
-   int i, j, p, f[XSIZE];
-   for(i=0;i<XSIZE;i++) bm_gs[i]=0;
+   int i, j, p, f[m + 1];
+   for(i=0;i<m + 1;i++) bm_gs[i]=0;
    f[m]=j=m+1;
    for (i=m; i > 0; i--) {
       while (j <= m && x[i-1] != x[j-1]) {
@@ -64,8 +64,8 @@ void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
 
 int search(unsigned char *P, int m, unsigned char *T, int n)
 {
-   int i,j,s1,s2,k,h,count,hbcr[SIGMA],hbcl[SIGMA],gsR[XSIZE],gsL[XSIZE];
-   unsigned char c,Pr[XSIZE],P2[XSIZE];
+   int i,j,s1,s2,k,h,count,hbcr[SIGMA],hbcl[SIGMA],gsR[m + 1],gsL[m + 1];
+   unsigned char Pr[m + 1];
 
    BEGIN_PREPROCESSING
    /* prprocessing */
@@ -79,13 +79,11 @@ int search(unsigned char *P, int m, unsigned char *T, int n)
 	Pre_GS(P,  m, gsR);
 	Pre_GS(Pr, m, gsL);
    
-   unsigned char lastch = P[m-1], firstch=P[0];
    int mm1 = m-1;
    END_PREPROCESSING
 
    /* searching */
    BEGIN_SEARCHING
-   int q = n/2;
 	s1 = mm1; s2 = n-m;
 	count = 0;
    k=hbcr[T[s1]];

--- a/src/algos/fs-w6.c
+++ b/src/algos/fs-w6.c
@@ -44,9 +44,24 @@
 #include "include/define.h"
 #include "include/main.h"
 
+/*
+ * Issues
+ * ======
+ * - bug in algorithm that references arrays at large positions when searching.
+ *
+ * Algorithm Bug
+ * -------------
+ * During search, the s and k values can get arbitrarily large, or sometimes negative,
+ * causing it to access impossible positions in the text T.
+ * See the warning note in the code below.
+ * I cannot see any buffer overflow; I believe this is caused by faulty algorithm logic.
+ *
+ * Requires much deeper understanding of the algorithm to determine this bug.
+ */
+
 void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
-   int i, j, p, f[XSIZE];
-   for(i=0;i<XSIZE;i++) bm_gs[i]=0;
+   int i, j, p, f[m + 1];
+   for(i=0;i<m + 1;i++) bm_gs[i]=0;
    f[m]=j=m+1;
    for (i=m; i > 0; i--) {
       while (j <= m && x[i-1] != x[j-1]) {
@@ -64,10 +79,10 @@ void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
 
 int search(unsigned char *P, int m, unsigned char *T, int n)
 {
-	int i, j,s1,s2,s3,s4,s5,s6,k1,k2,k3,k4,k5,k6,i1,i2,i3,i4;
+	int i, j,s1,s2,s3,s4,s5,s6,k1,k2,k3,k4,k5,k6;
     int l1,l2,l3,l4,l5,l6;
-	int h,count, hbcr[SIGMA], hbcl[SIGMA], gsR[XSIZE], gsL[XSIZE];
-   unsigned char c, Pr[XSIZE];
+	int h,count, hbcr[SIGMA], hbcl[SIGMA], gsR[m + 1], gsL[m + 1];
+   unsigned char Pr[m + 1];
     if(n<8) return -1;
     
 	/* proprocessing */
@@ -162,6 +177,10 @@ while(s1<=s2+mm1 || s3<=s4+mm1 || s5<=s6+mm1) {
           }
          s6-=gsL[m-i];
       }
+
+    //WARN: the s and k values can get arbitrarily large which causes a seg fault when it tries to access the text
+    //      some of them become negative, not sure if this ever becomes a problem.
+
       while( (k1=hbcr[T[s1]]) && (k2=hbcl[T[s2]])  && (k3=hbcr[T[s3]]) && (k4=hbcl[T[s4]])
           && (k5=hbcr[T[s5]]) && (k6=hbcl[T[s6]]) ) {
          s1+=k1; 

--- a/src/algos/fs-w8.c
+++ b/src/algos/fs-w8.c
@@ -44,9 +44,24 @@
 #include "include/define.h"
 #include "include/main.h"
 
+/*
+ * Issues
+ * ======
+ * - bug in algorithm that references arrays at large positions when searching.
+ *
+ * Algorithm Bug
+ * -------------
+ * During search, the s and k values can get arbitrarily large, or sometimes negative,
+ * causing it to access impossible positions in the text T.
+ * See the warning note in the code below.
+ * I cannot see any buffer overflow; I believe this is caused by faulty algorithm logic.
+ *
+ * Requires much deeper understanding of the algorithm to determine this bug.
+ */
+
 void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
-   int i, j, p, f[XSIZE];
-   for(i=0;i<XSIZE;i++) bm_gs[i]=0;
+   int i, j, p, f[m + 1];
+   for(i=0;i<m + 1;i++) bm_gs[i]=0;
    f[m]=j=m+1;
    for (i=m; i > 0; i--) {
       while (j <= m && x[i-1] != x[j-1]) {
@@ -64,10 +79,10 @@ void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
 
 int search(unsigned char *P, int m, unsigned char *T, int n)
 {
-	int i, j,s1,s2,s3,s4,s5,s6,s7,s8,k1,k2,k3,k4,k5,k6,k7,k8,i1,i2,i3,i4,h, count;
+	int i, j,s1,s2,s3,s4,s5,s6,s7,s8,k1,k2,k3,k4,k5,k6,k7,k8,count;
     int l1,l2,l3,l4,l5,l6,l7,l8;
-	int hbcr[SIGMA], hbcl[SIGMA], gsR[XSIZE], gsL[XSIZE];
-   unsigned char c, Pr[XSIZE];
+	int hbcr[SIGMA], hbcl[SIGMA], gsR[m + 1], gsL[m + 1];
+   unsigned char Pr[m + 1];
 
    /* proprocessing */
    BEGIN_PREPROCESSING
@@ -185,6 +200,10 @@ int search(unsigned char *P, int m, unsigned char *T, int n)
           }
          s8-=gsL[m-i];
       }
+
+       //WARN: the s and k values can get arbitrarily large which causes a seg fault when it tries to access the text
+       //      some of them become negative, not sure if this ever becomes a problem.
+
       while( (k1=hbcr[T[s1]]) && (k2=hbcl[T[s2]])  && (k3=hbcr[T[s3]]) && (k4=hbcl[T[s4]])
           && (k5=hbcr[T[s5]]) && (k6=hbcl[T[s6]]) && (k7=hbcr[T[s7]]) && (k8=hbcl[T[s8]]) ) {
          s1+=k1; 

--- a/src/algos/fs.c
+++ b/src/algos/fs.c
@@ -26,8 +26,8 @@
 #include "include/main.h"
 
 void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
-   int i, j, p, f[XSIZE];
-   for(i=0;i<XSIZE;i++) bm_gs[i]=0;
+   int i, j, p, f[m + 1];
+   for(i=0;i<m + 1;i++) bm_gs[i]=0;
    f[m]=j=m+1;
    for (i=m; i > 0; i--) {
       while (j <= m && x[i-1] != x[j-1]) {
@@ -44,7 +44,7 @@ void Pre_GS(unsigned char *x, int m, int bm_gs[]) {
 }
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int a,i, j, k, s, count, bc[SIGMA], gs[XSIZE];
+   int a,i, j, k, s, count, bc[SIGMA], gs[m + 1];
    char ch = x[m-1];
 
    /* Preprocessing */

--- a/src/algos/include/define.h
+++ b/src/algos/include/define.h
@@ -21,11 +21,8 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define FALSE 0
 #define TRUE 1
-#define XSIZE 4200 // maximal length of the pattern
 #define WSIZE 256  // greater int value fitting in a computer word
 #define SIGMA 256  // constant alphabet size
-//#define ALPHA       256				//constant alphabet size
-//#define ASIZE		256				//constant alphabet size
 #define UNDEFINED -1
 #define HALFDEFINED -2
 #define WORD 32 // computer word size (in bit)

--- a/src/algos/kmp.c
+++ b/src/algos/kmp.c
@@ -36,13 +36,13 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
       if (i<m && x[i] == x[j])
          kmpNext[i] = kmpNext[j];
       else
-         kmpNext[i] = j;
+         kmpNext[i] = j; // i == m here, so kmpNext needs m + 1 elements.
    }
 }
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, kmpNext[m], count;
+   int i, j, kmpNext[m + 1], count;
 
    /* Preprocessing */
    BEGIN_PREPROCESSING
@@ -60,7 +60,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
       j++;
       if (i >= m) {
          OUTPUT(j - i);
-         i = kmpNext[i];
+         i = kmpNext[i]; // i == m here so kmpNext needs m + 1 elements.
       }
    }
    END_SEARCHING

--- a/src/algos/kmp.c
+++ b/src/algos/kmp.c
@@ -42,7 +42,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, kmpNext[XSIZE], count;
+   int i, j, kmpNext[m], count;
 
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/kmpskip.c
+++ b/src/algos/kmpskip.c
@@ -64,7 +64,7 @@ int attempt(char *y, char *x, int m, int start, int wall) {
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
    int i, j, k, kmpStart, per, start, wall, count;
-   int kmpNext[XSIZE], list[XSIZE], mpNext[XSIZE], z[SIGMA];
+   int kmpNext[m], list[m], mpNext[m], z[SIGMA];
 
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/kmpskip.c
+++ b/src/algos/kmpskip.c
@@ -38,7 +38,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
       if (i<m && x[i] == x[j])
          kmpNext[i] = kmpNext[j];
       else
-         kmpNext[i] = j;
+         kmpNext[i] = j;  // i == m here, so kmpNext needs m + 1 elements.
    }
 }
 
@@ -64,7 +64,7 @@ int attempt(char *y, char *x, int m, int start, int wall) {
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
    int i, j, k, kmpStart, per, start, wall, count;
-   int kmpNext[m], list[m], mpNext[m], z[SIGMA];
+   int kmpNext[m + 1], list[m], mpNext[m], z[SIGMA];
 
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/lwfr2.c
+++ b/src/algos/lwfr2.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m here, so kmpNext requires m + 1 elements.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/lwfr3.c
+++ b/src/algos/lwfr3.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m, requires m + 1 elements in kmpNext.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/lwfr4.c
+++ b/src/algos/lwfr4.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m, kmpNext needs m + 1 elements.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/lwfr5.c
+++ b/src/algos/lwfr5.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m, kmpNext needs m + 1 elements.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/lwfr6.c
+++ b/src/algos/lwfr6.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m, kmpNext needs m + 1 elements.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/lwfr7.c
+++ b/src/algos/lwfr7.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m, kmpNext needs m + 1 elements.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/lwfr8.c
+++ b/src/algos/lwfr8.c
@@ -33,7 +33,7 @@ void preKmp(unsigned char *x, int m, int kmpNext[]) {
         if (i<m && x[i] == x[j])
             kmpNext[i] = kmpNext[j];
         else
-            kmpNext[i] = j;
+            kmpNext[i] = j; // i == m, kmpNext needs m + 1 elements.
     }
 }
 
@@ -58,7 +58,7 @@ void preprocessing(unsigned char *x, int m, char *F) {
 
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-    int i, j, p, b, lf, count, test, kmpNext[XSIZE];
+    int i, j, p, b, lf, count, test, kmpNext[m + 1];
     int tp, st;
     char F[256*256];
     unsigned short h;

--- a/src/algos/mp.c
+++ b/src/algos/mp.c
@@ -30,12 +30,12 @@ void preMp(unsigned char *x, int m, int mpNext[]) {
    while (i < m) {
       while (j > -1 && x[i] != x[j])
          j = mpNext[j];
-      mpNext[++i] = ++j;
+      mpNext[++i] = ++j; // pre-increment of i means that i can be equal to m, mpNext needs m + 1 elements.
    }
 }
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, mpNext[XSIZE], count;
+   int i, j, mpNext[m + 1], count;
 
    /* Preprocessing */
    BEGIN_PREPROCESSING
@@ -53,7 +53,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
       j++;
       if (i >= m) {
          OUTPUT(j - i);
-         i = mpNext[i];
+         i = mpNext[i]; // i == m here, mpNext needs m + 1 elements.
       }
    }
    END_SEARCHING

--- a/src/algos/ms.c
+++ b/src/algos/ms.c
@@ -28,7 +28,7 @@ typedef struct patternScanOrder {
    char c;
 } pattern;
 
-int minShift[XSIZE];
+int *minShift;  // pointer to int array to allow comparison function to access it.
 
 void computeMinShift(unsigned char *x, int m) {
    int i, j;
@@ -74,7 +74,7 @@ void preAdaptedGs(unsigned char *x, int m, int adaptedGs[], pattern *pat) {
    adaptedGs[0] = lshift = 1;
    for (ploc = 1; ploc <= m; ++ploc) {
       lshift = matchShift(x, m, ploc, lshift, pat);
-      adaptedGs[ploc] = lshift;
+      adaptedGs[ploc] = lshift; // ploc can == m, so adaptedGS requires m + 1 elements.
    }
    for (ploc = 0; ploc < m; ++ploc) {
       lshift = adaptedGs[ploc];
@@ -89,7 +89,6 @@ void preAdaptedGs(unsigned char *x, int m, int adaptedGs[], pattern *pat) {
    }
 }
 
-
 int maxShiftPcmp(pattern *pat1, pattern *pat2) {
    int dsh;
    dsh = minShift[pat2->loc] - minShift[pat1->loc];
@@ -97,9 +96,9 @@ int maxShiftPcmp(pattern *pat1, pattern *pat2) {
 }
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, qsBc[SIGMA], adaptedGs[XSIZE], count;
-   pattern pat[XSIZE];
-
+   int i, j, qsBc[SIGMA], adaptedGs[m + 1], count;
+   pattern pat[m + 1];
+   minShift = (int *)malloc(sizeof(int) * m);
    /* Preprocessing */
    BEGIN_PREPROCESSING
    computeMinShift(x ,m);
@@ -119,6 +118,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
          OUTPUT(j);
       j += MAX(adaptedGs[i], qsBc[y[j + m]]);
    }
+   free(minShift);
    END_SEARCHING
    return count;
 }

--- a/src/algos/om.c
+++ b/src/algos/om.c
@@ -41,7 +41,7 @@ void orderPattern(unsigned char *x, int m, int (*pcmp)(),
                   pattern *pat) {
     int i;
     
-    for (i = 0; i <= m; ++i) {
+    for (i = 0; i <= m; ++i) { // i can == m, so pat needs m + 1 elements.
         pat[i].loc = i;
         pat[i].c = x[i];
     }
@@ -101,7 +101,7 @@ void preAdaptedGs(unsigned char *x, int m, int adaptedGs[],
             ++lshift;
             lshift = matchShift(x, m, ploc, lshift, pat);
         }
-        adaptedGs[ploc] = lshift;
+        adaptedGs[ploc] = lshift; // ploc can == m, so adaptedGS needs m + 1 elements.
     }
 }
 
@@ -109,8 +109,8 @@ void preAdaptedGs(unsigned char *x, int m, int adaptedGs[],
 /* Optimal Mismatch string matching algorithm. */
 int search(unsigned char *x, int m, unsigned char *y, int n) {
 	int count = 0;
-    int i, j, adaptedGs[XSIZE], qsBc[SIGMA];
-    pattern pat[XSIZE];
+    int i, j, adaptedGs[m + 1], qsBc[SIGMA];
+    pattern pat[m + 1];
     
     /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/pbmh.c
+++ b/src/algos/pbmh.c
@@ -28,7 +28,7 @@
 
 int search(unsigned char *x, int m, unsigned char *y, int n)
 {
-   int i, j, s, tmp, count, hbc[SIGMA], v[XSIZE], FREQ[SIGMA];
+   int i, j, s, tmp, count, hbc[SIGMA], v[m], FREQ[SIGMA];
    /* Computing the frequency of characters */
    for(i=0; i<SIGMA; i++)	FREQ[i] = 0;
    for(i=0; i<100; i++) FREQ[y[i]]++;

--- a/src/algos/qlqs.c
+++ b/src/algos/qlqs.c
@@ -37,7 +37,7 @@ void preQsBc(unsigned char *P, int m, int qbc[]) {
 
 int search(unsigned char *P, int m, unsigned char *T, int n) {
    int i, s, k, count, qsf[SIGMA], qsb[SIGMA];
-   unsigned char R[XSIZE];
+   unsigned char R[m];
    
    BEGIN_PREPROCESSING
    reverse(P,m,R);

--- a/src/algos/sbndm-bmh.c
+++ b/src/algos/sbndm-bmh.c
@@ -24,12 +24,14 @@
 #include "include/define.h"
 #include "include/main.h"
 
+int search_large(unsigned char *x, int m, unsigned char *y, int n);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
    int j,i, last, first, hbc[SIGMA];
    unsigned int D, B[SIGMA], s;
    int mM1 = m-1;
    int mM2 = m-2;
-   int count = 0, restore[XSIZE+1], shift;
+   int count = 0, restore[m+1], shift;
    if(m>32) return search_large(x,m,y,n);   
    if(m<2) return -1;
     
@@ -92,7 +94,7 @@ int search_large(unsigned char *x, int m, unsigned char *y, int n) {
    unsigned int D, B[SIGMA], s;
    int mM1 = m-1;
    int mM2 = m-2;
-   int count = 0, restore[XSIZE+1], shift;
+   int count = 0, restore[m+1], shift;
 
    p_len = m;
    m = 32;

--- a/src/algos/sbndm.c
+++ b/src/algos/sbndm.c
@@ -25,12 +25,14 @@
 #include "include/define.h"
 #include "include/main.h"
 
+int search_large(unsigned char *x, int m, unsigned char *y, int n);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
    int j,i, last, first;
    unsigned int D, B[SIGMA], s;
    int mM1 = m-1;
    int mM2 = m-2;
-   int count = 0, restore[XSIZE+1], shift;
+   int count = 0, restore[m+1], shift;
 
    if(m>32) return search_large(x,m,y,n);
     if(m<2) return -1;
@@ -93,7 +95,7 @@ int search_large(unsigned char *x, int m, unsigned char *y, int n) {
    unsigned int D, B[SIGMA], s;
    int mM1 = m-1;
    int mM2 = m-2;
-   int count = 0, restore[XSIZE+1], shift;
+   int count = 0, restore[m+1], shift;
 
    p_len = m;
    m = 32;

--- a/src/algos/sebom.c
+++ b/src/algos/sebom.c
@@ -23,8 +23,8 @@
 #define FT(i,j)  LAMBDA[(i<<8) + j]
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int S[XSIZE], LAMBDA[SIGMA*SIGMA];
-   int *trans[XSIZE];
+   int S[m + 1], LAMBDA[SIGMA*SIGMA];
+   int *trans[m + 2];
    int i, j, p, q;
    int iMinus1, mMinus1, count;
    unsigned char c;
@@ -33,11 +33,11 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
     
    // Allocate space for oracle
    BEGIN_PREPROCESSING
-   for(i=0; i<=m+1; i++) trans[i] = (int *)malloc (sizeof(int)*(SIGMA));
+   for(i=0; i<=m+1; i++) trans[i] = (int *)malloc (sizeof(int)*(SIGMA)); // accesses position m + 1, requires m + 2 elements.
 
    // Preprocessing
    for(i=0; i<=m+1; i++) for(j=0; j<SIGMA; j++) trans[i][j]=UNDEFINED;
-   S[m] = m + 1;
+   S[m] = m + 1; // accesses position m, requires m + 1 elements.
    for (i = m; i > 0; --i) {
       iMinus1 = i - 1;
       c = x[iMinus1];

--- a/src/algos/sfbom.c
+++ b/src/algos/sfbom.c
@@ -23,8 +23,8 @@
 #define FT(i,j)  LAMBDA[(i<<8) + j]
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int S[XSIZE], LAMBDA[SIGMA*SIGMA];
-   int *trans[XSIZE];
+   int S[m + 1], LAMBDA[SIGMA*SIGMA];
+   int *trans[m + 2];
    int i, j, p, q;
    int iMinus1, mMinus1, count;
    unsigned char c;

--- a/src/algos/simon.c
+++ b/src/algos/simon.c
@@ -59,7 +59,8 @@ int preSimon(unsigned char *x, int m, List L[]) {
    int i, k, ell;
    List cell;
  
-   memset(L, 0, (m - 1)*sizeof(List));
+   //memset(L, 0, (m - 1)*sizeof(List));
+    memset(L, 0, m * sizeof(List));
    ell = -1;
    for (i = 1; i < m; ++i) {
       k = ell;
@@ -81,10 +82,9 @@ int preSimon(unsigned char *x, int m, List L[]) {
    return(ell);
 }
 
-
 int search(unsigned char *x, int m, unsigned char *y, int n) {
    int j, ell, state, count;
-   List L[XSIZE];
+   List L[m];
  
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/ssm.c
+++ b/src/algos/ssm.c
@@ -10,7 +10,7 @@
 void Horspool_Distance(int Horspool[], int Dist[], unsigned char *x, int m, int *dMax)
 {
     int i;
-    Dist[m]=0;
+    Dist[m]=0; // allocates to position m of Dist, so requires m + 1 elements.
     for (i = 0; i < SIGMA; i++) Horspool[i] = m;
     for (i = 0; i < m-1; i++)
     {
@@ -64,7 +64,7 @@ void PreProc(int Dist[], int Shift[], unsigned char *x, int m)
     /*----Compute the max shift of all shifts----*/
 
     for (i = 0; i < m; i++)
-        if (Shift[i] < Dist[m])
+        if (Shift[i] < Dist[m]) // accesses Dist at m, requires m + 1 elements.
             Shift[i] = Dist[m];
 }
 
@@ -73,7 +73,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 {
 
     int count, q, j, Max, jMax, Pos;
-    int Hors[SIGMA], Sht[XSIZE], Dis[XSIZE];
+    int Hors[SIGMA], Sht[m], Dis[m + 1];
     unsigned char xMax;
 
     /*Preprocessing phase-----------*/

--- a/src/algos/tbm.c
+++ b/src/algos/tbm.c
@@ -51,8 +51,8 @@ void suffixes(unsigned char *x, int m, int *suff) {
    }
 }
  
-void preBmGs(unsigned char *x, int m, int bmGs[]) {
-   int i, j, suff[XSIZE];
+void preBmGs(unsigned char *x, int m, int bmGs[]) { // bmGs is only accessed within m.
+   int i, j, suff[m];
    suffixes(x, m, suff);
    for (i = 0; i < m; ++i)
       bmGs[i] = m;
@@ -68,7 +68,7 @@ void preBmGs(unsigned char *x, int m, int bmGs[]) {
   
 int search(unsigned char *x, int m, unsigned char *y, int n) {
    int bcShift, i, j, shift, u, v, turboShift, count,
-       bmGs[XSIZE], bmBc[SIGMA];
+       bmGs[m], bmBc[SIGMA];
 
    /* Preprocessing */
    BEGIN_PREPROCESSING

--- a/src/algos/tndm.c
+++ b/src/algos/tndm.c
@@ -25,8 +25,10 @@
 #include "include/define.h"
 #include "include/main.h"
 
+int search_large(unsigned char *x, int m, unsigned char *y, int n);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i,j,s,last, restore[XSIZE+1];
+   int i,j,s,last, restore[m+1];
    unsigned int d, B[SIGMA];
    int count = 0;
    if(m>32) return search_large(x,m,y,n);
@@ -97,7 +99,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 
 int search_large(unsigned char *x, int m, unsigned char *y, int n)
 {
-   int i,j,s,last, restore[XSIZE+1], p_len, k;
+   int i,j,s,last, restore[m+1], p_len, k;
    unsigned int D, B[SIGMA];
    int count = 0;
    p_len = m;
@@ -118,7 +120,7 @@ int search_large(unsigned char *x, int m, unsigned char *y, int n)
       if (s & ((unsigned int)1<<(m-1))) {
          if(i > 0)  last = i; 
       }
-      restore[m-i] = last;
+      restore[m-i] = last; // restore array can be accessed at position m, so needs m + 1 elements.
       s <<= 1;
    }
    END_PREPROCESSING

--- a/src/algos/tndma.c
+++ b/src/algos/tndma.c
@@ -25,8 +25,10 @@
 #include "include/define.h"
 #include "include/main.h"
 
+int search_large(unsigned char *x, int m, unsigned char *y, int n);
+
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i,j,s,last, restore[XSIZE+1];
+   int i,j,s,last, restore[m+1];
    unsigned int d, B[SIGMA];
    int count = 0;
    if(m>32) return search_large(x,m,y,n);
@@ -46,7 +48,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
       if (s & ((unsigned int)1<<(m-1))) {
          if(i > 0)  last = i; 
       }
-      restore[m-i] = last;
+      restore[m-i] = last; // can access restore[m] so needs m + 1 elements.
       s <<= 1;
    }
    END_PREPROCESSING
@@ -99,7 +101,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 
 int search_large(unsigned char *x, int m, unsigned char *y, int n)
 {
-   int i,j,s,last, restore[XSIZE+1], p_len, k;
+   int i,j,s,last, restore[m+1], p_len, k;
    unsigned int D, B[SIGMA];
    int count = 0;
    

--- a/src/algos/tsw.c
+++ b/src/algos/tsw.c
@@ -41,7 +41,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
    int j, brBc_left[SIGMA][SIGMA], brBc_right[SIGMA][SIGMA];
    int i, a,b;
    int count;
-   unsigned char x1[XSIZE];
+   unsigned char x1[m];
    for(i=m-1, j=0; i>=0; i--, j++) x1[j]=x[i];
 
    /* Preprocessing */

--- a/src/algos/tvsbs-w2.c
+++ b/src/algos/tvsbs-w2.c
@@ -38,7 +38,7 @@
    int BrBcR[SIGMA][SIGMA], BrBcL[SIGMA][SIGMA];
    unsigned char firstch, lastch;
    BEGIN_PREPROCESSING
-   unsigned char xr[XSIZE];
+   unsigned char xr[m];
    for(i=0; i<m; i++) xr[i] = x[m-1-i];
    xr[m]='\0';
    count = 0;

--- a/src/algos/tvsbs-w2.c
+++ b/src/algos/tvsbs-w2.c
@@ -38,9 +38,9 @@
    int BrBcR[SIGMA][SIGMA], BrBcL[SIGMA][SIGMA];
    unsigned char firstch, lastch;
    BEGIN_PREPROCESSING
-   unsigned char xr[m];
+   unsigned char xr[m + 1];
    for(i=0; i<m; i++) xr[i] = x[m-1-i];
-   xr[m]='\0';
+   xr[m]='\0';  // access xr at position m so needs m + 1 elements.
    count = 0;
    TVSBSpreBrBc(x, m,  BrBcR);
    TVSBSpreBrBc(xr, m, BrBcL);

--- a/src/algos/tvsbs-w4.c
+++ b/src/algos/tvsbs-w4.c
@@ -39,7 +39,7 @@ void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
      int l1,l2,l3,l4;
    int BrBcR[SIGMA][SIGMA], BrBcL[SIGMA][SIGMA];
    unsigned char firstch, lastch;
-   unsigned char xr[XSIZE];
+   unsigned char xr[m];
    unsigned char c;
      if(n<m+2) return -1;
      if(m<2) return -1;

--- a/src/algos/tvsbs-w4.c
+++ b/src/algos/tvsbs-w4.c
@@ -39,14 +39,14 @@ void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
      int l1,l2,l3,l4;
    int BrBcR[SIGMA][SIGMA], BrBcL[SIGMA][SIGMA];
    unsigned char firstch, lastch;
-   unsigned char xr[m];
+   unsigned char xr[m + 1];
    unsigned char c;
      if(n<m+2) return -1;
      if(m<2) return -1;
      
    BEGIN_PREPROCESSING
    for(i=0; i<m; i++) xr[i] = x[m-1-i];
-   xr[m]='\0';
+   xr[m]='\0'; // access xr at position m so needs m + 1 elements.
    count = 0;
    TVSBSpreBrBc(x, m,  BrBcR);
    TVSBSpreBrBc(xr, m, BrBcL);

--- a/src/algos/tvsbs-w6.c
+++ b/src/algos/tvsbs-w6.c
@@ -43,7 +43,7 @@ void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
      if(m<2) return -1;
      
    BEGIN_PREPROCESSING
-   unsigned char xr[XSIZE];
+   unsigned char xr[m];
    unsigned char c, lastch, firstch;
    for(i=0; i<m; i++) xr[i] = x[m-1-i];
    xr[m]='\0';

--- a/src/algos/tvsbs-w6.c
+++ b/src/algos/tvsbs-w6.c
@@ -21,6 +21,15 @@
 #include "include/define.h"
 #include "include/main.h"
 
+/*
+ * Issues
+ * ------
+ *
+ * Seg-faults on large strings, e.g. 16000.  The s1, s2, s3, s4, s5 and s6 values get very large or small and
+ * try to access the text outside its bounds.  Seems to be a bug in the algorithm implementation (i.e. not buffer overflow
+ * or something else corrupting values).
+ */
+
 void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
    int a, b, i;
    for (a = 0; a < SIGMA; ++a)
@@ -43,10 +52,10 @@ void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
      if(m<2) return -1;
      
    BEGIN_PREPROCESSING
-   unsigned char xr[m];
+   unsigned char xr[m + 1];
    unsigned char c, lastch, firstch;
    for(i=0; i<m; i++) xr[i] = x[m-1-i];
-   xr[m]='\0';
+   xr[m]='\0'; // access xr at position m so needs m + 1 elements.
    count = 0;
    int mp1 = m+1, mm1=m-1;
    TVSBSpreBrBc(x, m,  BrBcR);

--- a/src/algos/tvsbs-w8.c
+++ b/src/algos/tvsbs-w8.c
@@ -17,9 +17,17 @@
  * download the tool at: http://www.dmi.unict.it/~faro/smart/
  */
 
-
 #include "include/define.h"
 #include "include/main.h"
+
+/*
+ * Issues
+ * ------
+ *
+ * Seg-faults on large strings, e.g. 16000.  The s1, s2, s3, s4, s5 and s6 values get very large or small and
+ * try to access the text outside its bounds.  Seems to be a bug in the algorithm implementation (i.e. not buffer overflow
+ * or something else corrupting values).
+ */
 
 void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
    int a, b, i;
@@ -39,14 +47,14 @@ void TVSBSpreBrBc(unsigned char *x, int m, int brBc[SIGMA][SIGMA]) {
      int l1,l2,l3,l4,l5,l6,l7,l8;
    int BrBcR[SIGMA][SIGMA], BrBcL[SIGMA][SIGMA];
    unsigned char firstCh, lastCh;
-   unsigned char xr[XSIZE];
+   unsigned char xr[m + 1];
    unsigned char c;
      if(n<m+2) return -1;
      if(m<2) return -1;
 
    BEGIN_PREPROCESSING
    for(i=0; i<m; i++) xr[i] = x[m-1-i];
-   xr[m]='\0';
+   xr[m]='\0'; // access xr at position m so needs m + 1 elements.
    count = 0;
    int mPlus1 = m+1;
    TVSBSpreBrBc(x, m,  BrBcR);

--- a/src/algos/zt.c
+++ b/src/algos/zt.c
@@ -45,7 +45,7 @@ void suffixes(unsigned char *x, int m, int *suff) {
 }
  
 void preBmGs(unsigned char *x, int m, int bmGs[]) {
-   int i, j, suff[XSIZE];
+   int i, j, suff[m];
  
    suffixes(x, m, suff);
  
@@ -74,7 +74,7 @@ void preBmGs(unsigned char *x, int m, int bmGs[]) {
 }
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
-   int i, j, ztBc[SIGMA][SIGMA], bmGs[XSIZE], count;
+   int i, j, ztBc[SIGMA][SIGMA], bmGs[m], count;
 
    /* Preprocessing */
    BEGIN_PREPROCESSING


### PR DESCRIPTION
Old smart hard coded a pattern length limit of XSIZE, which was set to 4200.  New smart can have arbitrarily sized patterns.  This PR removes references to XSIZE, and replaces them with m (or a larger value where appropriate).

**Methodology**
All algorithms were tested with XSIZE = 4200, and a pattern length of 4200, to ensure they handle a full size pattern already, and whether they handle a pattern of 4199.  Many algorithms seg-fault when m == XSIZE, as they actually need m + 1 elements.

Following analysis of the code to see whether access at position m or beyond occurs, XSIZE is replaced with m, m + 1 or beyond as appropriate.

After the change, the algorithms were retested to ensure they now work with any pattern size.  Some algorithms still have other problems which are not resolved by these changes, which are mentioned in the commits and code comments.  They will have to be addressed separately.