### PR TITLE
Pattern length control

### DIFF
--- a/src/algorithms.h
+++ b/src/algorithms.h
@@ -10,8 +10,8 @@
 #include "config.h"
 #include "utils.h"
 
-static const char *ALGO_COLUMN_FORMAT = "%-18s ";
-static const int ALGO_NUM_COLUMNS = 6; //TODO: calculate from algo name len?  Max algo name lens?
+static const char *ALGO_COLUMN_FORMAT = "%-*s ";
+static const int ALGO_NUM_COLUMNS = (MAX_LINE_LEN / ALGO_NAME_LEN);
 
 /*
  * Function signature typedef of the internal search function called to benchmark algorithms.
@@ -373,7 +373,7 @@ void print_algorithms_in_tabular_format(const algo_info_t *algorithms)
             for (int j = i; j < i + ALGO_NUM_COLUMNS; j++)
             {
                 set_upper_case_algo_name(upper_case_algo_name, algorithms->algo_names[j]);
-                printf(ALGO_COLUMN_FORMAT, upper_case_algo_name);
+                printf(ALGO_COLUMN_FORMAT, ALGO_NAME_LEN, upper_case_algo_name);
             }
             printf("\n");
         }
@@ -384,7 +384,7 @@ void print_algorithms_in_tabular_format(const algo_info_t *algorithms)
             for (int i = algorithms->num_algos - remaining_columns; i < algorithms->num_algos; i++)
             {
                 set_upper_case_algo_name(upper_case_algo_name, algorithms->algo_names[i]);
-                printf(ALGO_COLUMN_FORMAT, upper_case_algo_name);
+                printf(ALGO_COLUMN_FORMAT, ALGO_NAME_LEN, upper_case_algo_name);
             }
             printf("\n");
         }

--- a/src/commands.h
+++ b/src/commands.h
@@ -220,6 +220,7 @@ void print_run_usage_and_exit(const char *command)
     print_help_line("Performs experimental results using random text with an alphabet A between 1 and 256 inclusive.", OPTION_SHORT_RANDOM_TEXT, OPTION_LONG_RANDOM_TEXT, "A");
     print_help_line("Performs experimental results using text specified in parameter T.", OPTION_SHORT_SEARCH_DATA, OPTION_LONG_SEARCH_DATA, "T");
     print_help_line("Set the minimum and maximum length of random patterns to benchmark between L and U (included).", OPTION_SHORT_PATTERN_LEN, OPTION_LONG_PATTERN_LEN, "L U");
+    print_help_line("If you only provide a single parameter L, then only that pattern length will be used.", "", "", "L");
     print_help_line("Performs experimental results using a single pattern specified in parameter P.", OPTION_SHORT_PATTERN, OPTION_LONG_PATTERN, "P");
     print_help_line("Benchmarks a set of algorithms named N.algos in the config folder, in addition to any algorithms specified directly.", OPTION_SHORT_USE_NAMED, OPTION_LONG_USE_NAMED, "N");
     print_help_line("Benchmarks all the algorithms.", FLAG_SHORT_ALL_ALGOS, FLAG_LONG_ALL_ALGOS, "");

--- a/src/commands.h
+++ b/src/commands.h
@@ -64,6 +64,16 @@ void print_subcommand_usage_and_exit(const char *command)
 enum algo_sources {ALGO_REGEXES, ALL_ALGOS, SELECTED_ALGOS, NAMED_SET_ALGOS};
 
 /*
+ * A struct to hold information about what pattern lengths to benchmark or test with.
+ */
+typedef struct pattern_len_info {
+    int pattern_min_len;
+    int pattern_max_len;
+    char increment_operator;
+    int increment_by;
+} pattern_len_info_t;
+
+/*
  * Shared commands
  */
 static char *const OPTION_SHORT_SEED = "-rs";
@@ -72,6 +82,53 @@ static char *const OPTION_SHORT_USE_NAMED = "-use";
 static char *const OPTION_LONG_USE_NAMED = "--use-algos";
 static char *const FLAG_SHORT_ALL_ALGOS = "-all";
 static char *const FLAG_LONG_ALL_ALGOS = "--all-algos";
+static char *const OPTION_SHORT_PATTERN_LEN = "-plen";
+static char *const OPTION_LONG_PATTERN_LEN = "--patt-len";
+static char *const OPTION_SHORT_INCREMENT= "-inc";
+static char *const OPTION_LONG_INCREMENT = "--increment";
+
+/*
+ * Returns the next pattern length given the pattern length increment options and the current length.
+ * Guarantees that the next pattern length will be at least one greater than the current length.
+ */
+int next_pattern_length(const pattern_len_info_t *pattern_info, int current_length)
+{
+    int next_length = current_length;
+    if (pattern_info->increment_operator == '*')
+    {
+        next_length *= pattern_info->increment_by;
+    }
+    else if (pattern_info->increment_operator == '+')
+    {
+        next_length += pattern_info->increment_by;
+    }
+    else
+    {
+        error_and_exit("Unknown pattern length increment operator was set: %c", pattern_info->increment_operator);
+    }
+
+    if (next_length <= current_length)
+    {
+        next_length = current_length + 1;
+    }
+
+    return next_length;
+}
+
+/*
+ * Returns the number of different pattern lengths to be tested or benchmarked.
+ */
+int get_num_pattern_lengths(const pattern_len_info_t *pattern_info)
+{
+    int num_patterns = 0;
+    int value = pattern_info->pattern_min_len;
+    while (value <= pattern_info->pattern_max_len)
+    {
+        value = next_pattern_length(pattern_info, value);
+        num_patterns++;
+    }
+    return num_patterns;
+}
 
 
 /************************************
@@ -91,10 +148,6 @@ static char *const OPTION_SHORT_TEXT_SOURCE = "-text";
 static char *const OPTION_LONG_TEXT_SOURCE = "--text-files";
 static char *const OPTION_SHORT_RANDOM_TEXT = "-rand";
 static char *const OPTION_LONG_RANDOM_TEXT = "--rand-text";
-static char *const OPTION_SHORT_PATTERN_LEN = "-plen";
-static char *const OPTION_LONG_PATTERN_LEN = "--patt-len";
-static char *const OPTION_SHORT_INCREMENT= "-inc";
-static char *const OPTION_LONG_INCREMENT = "--increment";
 static char *const OPTION_SHORT_PATTERN = "-pat";
 static char *const OPTION_LONG_PATTERN = "--pattern";
 static char *const OPTION_SHORT_SEARCH_DATA = "-data";
@@ -113,14 +166,14 @@ static char *const FLAG_SHORT_PREPROCESSING_TIME = "-pre";
 static char *const FLAG_LONG_PREPROCESSING_TIME = "--pre-time";
 static char *const FLAG_SHORT_FILL_BUFFER = "-fb";
 static char *const FLAG_LONG_FILL_BUFFER = "--fill-buffer";
-
 static char *const FLAG_SHORT_PATTERN_LENGTHS_SHORT = "-short";
 static char *const FLAG_LONG_PATTERN_LENGTHS_SHORT = "--short-patterns";
 static char *const FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT = "-vshort";
 static char *const FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT = "--very-short";
-static char *const FLAG_TEXT_OUTPUT = "-txt";                                      //TODO: output of results.
-static char *const FLAG_LATEX_OUTPUT = "-tex";                                     //TODO: output of results.
-static char *const FLAG_PHP_OUTPUT = "-php";                                       //TODO: output of results.
+
+static char *const FLAG_TEXT_OUTPUT = "-txt";     //TODO: output of results.
+static char *const FLAG_LATEX_OUTPUT = "-tex";    //TODO: output of results.
+static char *const FLAG_PHP_OUTPUT = "-php";      //TODO: output of results.
 
 /*
  * Type of data source to use for benchmarking.
@@ -146,10 +199,7 @@ typedef struct run_command_opts
     int text_size;                               // Size of the text buffer for benchmarking.
     int fill_buffer;                             // Boolean flag - whether to replicate data to fill up a buffer.
     int alphabet_size;                           // Size of the alphabet to use when creating random texts.
-    int pattern_min_len;                         // minimum length of pattern to be benchmarked.
-    int pattern_max_len;                         // maximum length of pattern to be benchmarked.
-    char increment_operator;                     // + or * to indicate the increment operator to use.
-    int increment_by;                            // amount to increment the pattern length by, with either addition or multiplication.
+    pattern_len_info_t pattern_info;             // Information about what pattern lengths to benchmark.
     int num_runs;                                // Number of patterns of a given length to benchmark.
     int time_limit_millis;                       // Number of milliseconds before an algorithm has timed out.
     long random_seed;                            // Random seed used to generate text or patterns.
@@ -192,10 +242,10 @@ void init_run_command_opts(run_command_opts_t *opts)
     opts->cpu_to_pin  = -1;
     opts->alphabet_size = SIGMA;
     opts->text_size = TEXT_SIZE_DEFAULT;
-    opts->pattern_min_len = PATTERN_MIN_LEN_DEFAULT;
-    opts->pattern_max_len = PATTERN_MAX_LEN_DEFAULT;
-    opts->increment_operator = INCREMENT_OPERATOR;
-    opts->increment_by = INCREMENT_BY;
+    opts->pattern_info.pattern_min_len = PATTERN_MIN_LEN_DEFAULT;
+    opts->pattern_info.pattern_max_len = PATTERN_MAX_LEN_DEFAULT;
+    opts->pattern_info.increment_operator = INCREMENT_MULTIPLY_OPERATOR;
+    opts->pattern_info.increment_by = INCREMENT_BY;
     opts->num_runs = NUM_RUNS_DEFAULT;
     opts->time_limit_millis = TIME_LIMIT_MILLIS_DEFAULT;
     opts->random_seed = time(NULL);
@@ -214,7 +264,7 @@ void print_run_usage_and_exit(const char *command)
 {
     print_logo();
 
-    printf("\n usage: %s [algo names...] [-text | -rand | -data | -plen | -pat | -use | -all | -runs | -ts | -fb | -rs | -pre | -occ | -tb | -pin | -h]\n\n", command);
+    printf("\n usage: %s [algo names...] [-text | -rand | -data | -plen | -inc | -short | -vshort | -pat | -use | -all | -runs | -ts | -fb | -rs | -pre | -occ | -tb | -pin | -h]\n\n", command);
 
     printf("\tYou can specify algorithms to benchmark directly as POSIX regular expressions, e.g. smart run bsdm.* hor ...\n");
     printf("\tIf you do not specify any algorithms on the command line or by another command, the default selected algorithms will be used.\n\n");
@@ -227,14 +277,17 @@ void print_run_usage_and_exit(const char *command)
     print_help_line("Performs experimental results using text specified in parameter T.", OPTION_SHORT_SEARCH_DATA, OPTION_LONG_SEARCH_DATA, "T");
     print_help_line("Set the minimum and maximum length of random patterns to benchmark between L and U (included).", OPTION_SHORT_PATTERN_LEN, OPTION_LONG_PATTERN_LEN, "L U");
     print_help_line("If you only provide a single parameter L, then only that pattern length will be used.", "", "", "L");
+    print_help_line("Increments the pattern lengths with operator O and value V, e.g. '+1'. Default is '*2'.", OPTION_SHORT_INCREMENT, OPTION_LONG_INCREMENT, "O V");
+    print_help_line("To add by a fixed amount V, use operator +", "", "", "+ V");
+    print_help_line("To multiply by a fixed amount V, use operator *", "", "", "* V");
+    print_help_line("Performs experimental results using short length patterns (from 2 to 32 incrementing by 2)", FLAG_SHORT_PATTERN_LENGTHS_SHORT, FLAG_LONG_PATTERN_LENGTHS_SHORT, "");
+    print_help_line("Performs experimental results using very short length patterns (from 1 to 16 incrementing by 1)", FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT, FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT, "");
     print_help_line("Performs experimental results using a single pattern specified in parameter P.", OPTION_SHORT_PATTERN, OPTION_LONG_PATTERN, "P");
     print_help_line("Benchmarks a set of algorithms named N.algos in the config folder, in addition to any algorithms specified directly.", OPTION_SHORT_USE_NAMED, OPTION_LONG_USE_NAMED, "N");
     print_help_line("Benchmarks all the algorithms.", FLAG_SHORT_ALL_ALGOS, FLAG_LONG_ALL_ALGOS, "");
     print_help_line("Computes running times as the mean of N runs (default 500)", OPTION_SHORT_NUM_RUNS, OPTION_LONG_NUM_RUNS, "N");
     print_help_line("Set the upper bound dimension S (in Mb) of the text used for experimental results (default 1Mb).", OPTION_SHORT_TEXT_SIZE, OPTION_LONG_TEXT_SIZE, "S");
     print_help_line("Fills the text buffer up to its maximum size by copying earlier data until full.", FLAG_SHORT_FILL_BUFFER, FLAG_LONG_FILL_BUFFER, "");
-    print_help_line("Computes experimental results using short length patterns (from 2 to 32 incrementing by 2)", FLAG_SHORT_PATTERN_LENGTHS_SHORT, FLAG_LONG_PATTERN_LENGTHS_SHORT, "");
-    print_help_line("Computes experimental results using very short length patterns (from 1 to 16 incrementing by 1)", FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT, FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT, "");
     print_help_line("Sets the random seed to integer S, ensuring tests and benchmarks can be precisely repeated.", OPTION_SHORT_SEED, OPTION_LONG_SEED, "S");
     print_help_line("Reports preprocessing times and searching times separately", FLAG_SHORT_PREPROCESSING_TIME, FLAG_LONG_PREPROCESSING_TIME, "");
     print_help_line("Prints the total number of occurrences", FLAG_SHORT_OCCURRENCE, FLAG_LONG_OCCURRENCE, "");
@@ -359,6 +412,7 @@ typedef struct test_command_opts
     const char *algo_names[MAX_SELECT_ALGOS];      // algo_names to test, as POSIX regular expressions.
     int num_algo_names;                            // Number of algo names recorded.
     long random_seed;                              // Random seed used to generate text or patterns.
+    pattern_len_info_t pattern_info;               // Info about what pattern sizes to test random patterns with.
     int debug;                                     // If set will re-call a failing search function with the failing parameters.
     int quick;                                     // Whether to run quick tests.
 } test_command_opts_t;
@@ -368,14 +422,18 @@ typedef struct test_command_opts
  */
 void init_test_command_opts(test_command_opts_t *opts)
 {
-    opts->algo_source  = ALGO_REGEXES;          // default is just user specified algo_names unless a command says different.
+    opts->algo_source  = ALGO_REGEXES;       // default is just user specified algo_names unless a command says different.
     opts->named_set    = NULL;
     for (int i = 0; i < MAX_SELECT_ALGOS; i++)
         opts->algo_names[i] = NULL;
     opts->num_algo_names = 0;
-    opts->random_seed  = time(NULL);   // default unless -seed option is specified.
+    opts->random_seed  = time(NULL);   // default is random seed set by the current time, unless -seed option is specified.
     opts->debug = 0;
     opts->quick = 0;
+    opts->pattern_info.pattern_min_len = 0;            // Only set to a real operator if we are specifying pattern lengths for test.
+    opts->pattern_info.pattern_max_len = 0;            // Only set to a real operator if we are specifying pattern lengths for test.
+    opts->pattern_info.increment_operator = INCREMENT_MULTIPLY_OPERATOR;
+    opts->pattern_info.increment_by = INCREMENT_BY;
 }
 
 /*
@@ -385,7 +443,7 @@ void print_test_usage_and_exit(const char *command)
 {
     print_logo();
 
-    printf("\n usage: %s test [algo1, algo2, ...] | -all | -sel | -use {name} | -rs | -q | -d | -h\n\n", command);
+    printf("\n usage: %s test [algo1, algo2, ...] | -all | -sel | -use | -plen |-inc | -rs | -q | -d | -h\n\n", command);
 
     info("Tests a set of smart algorithms for correctness with a variety of fixed and randomized tests.");
     info("You can specify the algorithms to test directly using POSIX extended regular expressions, e.g. test hor wfr.*");
@@ -394,6 +452,11 @@ void print_test_usage_and_exit(const char *command)
     print_help_line("Tests all of the algorithms smart finds in its algo search paths.", FLAG_SHORT_ALL_ALGOS, FLAG_LONG_ALL_ALGOS, "");
     print_help_line("Tests the currently selected algorithms in addition to any algorithms specified directly.", OPTION_SHORT_TEST_SELECTED, OPTION_LONG_TEST_SELECTED, "");
     print_help_line("Tests a set of algorithms named N.algos in the config folder, in addition to any algorithms specified directly.", OPTION_SHORT_USE_NAMED, OPTION_LONG_USE_NAMED, "N");
+    print_help_line("Set the minimum and maximum length of random patterns to test between L and U (included).", OPTION_SHORT_PATTERN_LEN, OPTION_LONG_PATTERN_LEN, "L U");
+    print_help_line("If you only provide a single parameter L, then only that pattern length will be used.", "", "", "L");
+    print_help_line("Increments the pattern lengths with operator O and value V, e.g. +1 or *2", OPTION_SHORT_INCREMENT, OPTION_LONG_INCREMENT, "O V");
+    print_help_line("To add by a fixed amount V, use operator +", "", "", "+ V");
+    print_help_line("To multiply by a fixed amount V, use operator *", "", "", "* V");
     print_help_line("Sets the random seed to integer S, ensuring tests can be precisely repeated.", OPTION_SHORT_SEED, OPTION_LONG_SEED, "S");
     print_help_line("Runs tests faster by testing less exhaustively.", OPTION_SHORT_QUICK_TESTS, OPTION_LONG_QUICK_TESTS, "");
     print_help_line("Useful to get fast feedback, but all tests should pass before benchmarking against other algorithms.", "", "", "");

--- a/src/commands.h
+++ b/src/commands.h
@@ -93,6 +93,8 @@ static char *const OPTION_SHORT_RANDOM_TEXT = "-rand";
 static char *const OPTION_LONG_RANDOM_TEXT = "--rand-text";
 static char *const OPTION_SHORT_PATTERN_LEN = "-plen";
 static char *const OPTION_LONG_PATTERN_LEN = "--patt-len";
+static char *const OPTION_SHORT_INCREMENT= "-inc";
+static char *const OPTION_LONG_INCREMENT = "--increment";
 static char *const OPTION_SHORT_PATTERN = "-pat";
 static char *const OPTION_LONG_PATTERN = "--pattern";
 static char *const OPTION_SHORT_SEARCH_DATA = "-data";
@@ -112,10 +114,10 @@ static char *const FLAG_LONG_PREPROCESSING_TIME = "--pre-time";
 static char *const FLAG_SHORT_FILL_BUFFER = "-fb";
 static char *const FLAG_LONG_FILL_BUFFER = "--fill-buffer";
 
-static char *const FLAG_SHORT_PATTERN_LENGTHS_SHORT = "-short";                    //TODO: support this command.
-static char *const FLAG_LONG_PATTERN_LENGTHS_SHORT = "--short-patterns";           //TODO: support this command.
-static char *const FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT = "-vshort";              //TODO: support this command.
-static char *const FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT = "--very-short-patterns"; //TODO: support this command.
+static char *const FLAG_SHORT_PATTERN_LENGTHS_SHORT = "-short";
+static char *const FLAG_LONG_PATTERN_LENGTHS_SHORT = "--short-patterns";
+static char *const FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT = "-vshort";
+static char *const FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT = "--very-short";
 static char *const FLAG_TEXT_OUTPUT = "-txt";                                      //TODO: output of results.
 static char *const FLAG_LATEX_OUTPUT = "-tex";                                     //TODO: output of results.
 static char *const FLAG_PHP_OUTPUT = "-php";                                       //TODO: output of results.
@@ -146,6 +148,8 @@ typedef struct run_command_opts
     int alphabet_size;                           // Size of the alphabet to use when creating random texts.
     int pattern_min_len;                         // minimum length of pattern to be benchmarked.
     int pattern_max_len;                         // maximum length of pattern to be benchmarked.
+    char increment_operator;                     // + or * to indicate the increment operator to use.
+    int increment_by;                            // amount to increment the pattern length by, with either addition or multiplication.
     int num_runs;                                // Number of patterns of a given length to benchmark.
     int time_limit_millis;                       // Number of milliseconds before an algorithm has timed out.
     long random_seed;                            // Random seed used to generate text or patterns.
@@ -190,6 +194,8 @@ void init_run_command_opts(run_command_opts_t *opts)
     opts->text_size = TEXT_SIZE_DEFAULT;
     opts->pattern_min_len = PATTERN_MIN_LEN_DEFAULT;
     opts->pattern_max_len = PATTERN_MAX_LEN_DEFAULT;
+    opts->increment_operator = INCREMENT_OPERATOR;
+    opts->increment_by = INCREMENT_BY;
     opts->num_runs = NUM_RUNS_DEFAULT;
     opts->time_limit_millis = TIME_LIMIT_MILLIS_DEFAULT;
     opts->random_seed = time(NULL);
@@ -227,8 +233,8 @@ void print_run_usage_and_exit(const char *command)
     print_help_line("Computes running times as the mean of N runs (default 500)", OPTION_SHORT_NUM_RUNS, OPTION_LONG_NUM_RUNS, "N");
     print_help_line("Set the upper bound dimension S (in Mb) of the text used for experimental results (default 1Mb).", OPTION_SHORT_TEXT_SIZE, OPTION_LONG_TEXT_SIZE, "S");
     print_help_line("Fills the text buffer up to its maximum size by copying earlier data until full.", FLAG_SHORT_FILL_BUFFER, FLAG_LONG_FILL_BUFFER, "");
-    //print_help_line("Computes experimental results using short length patterns (from 2 to 32)", FLAG_SHORT_PATTERN_LENGTHS_SHORT, FLAG_SHORT_PATTERN_LENGTHS_LONG, "");
-    //print_help_line("Computes experimental results using very short length patterns (from 1 to 16)", FLAG_VERY_SHORT_PATTERN_LENGTHS_SHORT, FLAG_VERY_SHORT_PATTERN_LENGTHS_LONG, "");
+    print_help_line("Computes experimental results using short length patterns (from 2 to 32 incrementing by 2)", FLAG_SHORT_PATTERN_LENGTHS_SHORT, FLAG_LONG_PATTERN_LENGTHS_SHORT, "");
+    print_help_line("Computes experimental results using very short length patterns (from 1 to 16 incrementing by 1)", FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT, FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT, "");
     print_help_line("Sets the random seed to integer S, ensuring tests and benchmarks can be precisely repeated.", OPTION_SHORT_SEED, OPTION_LONG_SEED, "S");
     print_help_line("Reports preprocessing times and searching times separately", FLAG_SHORT_PREPROCESSING_TIME, FLAG_LONG_PREPROCESSING_TIME, "");
     print_help_line("Prints the total number of occurrences", FLAG_SHORT_OCCURRENCE, FLAG_LONG_OCCURRENCE, "");

--- a/src/defines.h
+++ b/src/defines.h
@@ -57,6 +57,8 @@
 #define TEXT_SIZE_DEFAULT 1048576         // default size of text buffer for benchmarking
 #define PATTERN_MIN_LEN_DEFAULT 2         // default minimum size of pattern to benchmark.
 #define PATTERN_MAX_LEN_DEFAULT 4096      // default maximum size of pattern to benchmark.
+#define INCREMENT_OPERATOR '*'            // default pattern increment is to multiply by 2
+#define INCREMENT_BY 2                    // default pattern increment is to multiply by 2
 #define NUM_RUNS_DEFAULT 500              // default number of patterns of a given size to benchmark with.
 #define TIME_LIMIT_MILLIS_DEFAULT 300     // default time limit in milliseconds for a search to pass benchmarking.
 #define CPU_PIN_DEFAULT PIN_LAST_CPU      // default CPU pinning - can be [off | last | {digit}]

--- a/src/defines.h
+++ b/src/defines.h
@@ -19,7 +19,7 @@
  */
 #define MAX_PATH_LENGTH 2048              // Maximum file path length.
 #define ALGO_NAME_LEN 25                  // Maximum length of an algorithm name string + 1 for null terminator char.
-#define MAX_DATA_SOURCES 32               // max number of algorithm name/regexes eo specify on command line.
+#define MAX_DATA_SOURCES 32               // max number of algorithm name/regexes to specify on command line.
 #define MAX_SEARCH_PATHS 32               // maximum search paths for data or algo_names set via environment variable.
 #define MAX_SELECT_ALGOS 2048             // maximum number of algorithms which can be selected for benchmarking.
 #define MAX_DATA_FILES 128                // max number of different files to load to fill the benchmark text buffer.
@@ -57,7 +57,7 @@
 #define TEXT_SIZE_DEFAULT 1048576         // default size of text buffer for benchmarking
 #define PATTERN_MIN_LEN_DEFAULT 2         // default minimum size of pattern to benchmark.
 #define PATTERN_MAX_LEN_DEFAULT 4096      // default maximum size of pattern to benchmark.
-#define INCREMENT_OPERATOR '*'            // default pattern increment is to multiply by 2
+#define INCREMENT_MULTIPLY_OPERATOR '*'   // default pattern increment is to multiply by 2
 #define INCREMENT_BY 2                    // default pattern increment is to multiply by 2
 #define NUM_RUNS_DEFAULT 500              // default number of patterns of a given size to benchmark with.
 #define TIME_LIMIT_MILLIS_DEFAULT 300     // default time limit in milliseconds for a search to pass benchmarking.
@@ -67,6 +67,7 @@
  * Test settings
  */
 #define TEST_TEXT_SIZE 8192               // size of text buffer for testing.
+#define TEST_PATTERN_MIN_LEN 1            // min length of random pattern to use when testing.
 #define TEST_PATTERN_MAX_LEN 2048         // max length of random patterns to use when testing.
 #define MAX_FAILURE_MESSAGES 32           // max number of failure messages to record.
 /*

--- a/src/parser.h
+++ b/src/parser.h
@@ -26,8 +26,10 @@ static char *const ERROR_PARAM_TOO_BIG = "%sparameter for option %s is bigger th
 static char *const ERROR_CPU_PINNING_PARAMETER = "%sIncorrect parameter %s for option %s.  Must be off | last | {digit}%s";
 static char *const ERROR_MISSING_PARAMETER = "%soption %s needs a parameter, next is a -flag parameter: %s%s";
 static char *const ERROR_NO_DATA_SOURCE_DEFINED = "%sno data source is defined with either %s or %s%s";
+static char *const ERROR_TOO_MANY_DATA_SOURCES_DEFINED = "%sToo many data source are defined with either %s.  Max is %d.%s";
 static char *const ERROR_UNRECOGNISED_OPTION = "%s%s: unrecognized option %s%s";
 static char *const ERROR_NO_ALGORITHMS_DEFINED = "%sno algorithms specified for test.%s";
+static char *const ERROR_TOO_MANY_PATTERN_LENGTHS = "%sToo many patterns lengths specified: %d, from %d to %d, incrementing %c %d.  Max = %d%s";
 static char *const ERROR_PARAM_TOO_SHORT = "%sParameter '%s' value for option %s must be at least %d long.%s";
 static char *const ERROR_INCREMENT_PLUS_OR_TIMES = "%sIncrement option %s parameter '%s' must start with + or *%s";
 static char *const ERROR_HEADER = "Error in input parameters: ";
@@ -90,6 +92,23 @@ void check_string_too_short(const char *param, int minlen, const char *option)
     {
         error_and_exit(ERROR_PARAM_TOO_SHORT, ERROR_HEADER, param, option, minlen, ERROR_FOOTER);
 
+    }
+}
+
+/*
+ * Checks that the num pattern lengths defined (if they are) do not exceed the maximum number of pattern lengths.
+ */
+void check_num_pattern_lengths(pattern_len_info_t *pattern_info)
+{
+    if (pattern_info->pattern_min_len > 0) // if set to 0, no pattern lengths are defined.
+    {
+        int num_pattern_lengths = get_num_pattern_lengths(pattern_info);
+        if (num_pattern_lengths > NUM_PATTERNS_MAX)
+        {
+            error_and_exit(ERROR_TOO_MANY_PATTERN_LENGTHS, ERROR_HEADER, num_pattern_lengths,
+                           pattern_info->pattern_min_len, pattern_info->pattern_max_len, pattern_info->increment_operator,
+                           pattern_info->increment_by, NUM_PATTERNS_MAX, ERROR_FOOTER);
+        }
     }
 }
 
@@ -182,7 +201,10 @@ int parse_text(run_command_opts_t *opts, int curr_arg, int argc, const char **ar
         name_arg++;
     }
 
-    //TODO: test that there are not more parameters after MAX_DATA_SOURCES?
+    if (curr_arg + name_arg + 1 < argc && !is_command_option(argv[curr_arg + name_arg + 1]))
+    {
+        error_and_exit(ERROR_TOO_MANY_DATA_SOURCES_DEFINED, ERROR_HEADER, OPTION_LONG_TEXT_SOURCE, MAX_DATA_SOURCES, ERROR_FOOTER);
+    }
 
     if (name_arg > 0)
     {
@@ -219,41 +241,25 @@ int parse_random_text(run_command_opts_t *opts, int curr_arg, int argc, const ch
  * Parses the pattern length parameters, setting the minimum and maxiumum bounds to search with.
  * Returns the number of parameters parsed.
  */
-int parse_pattern_len(run_command_opts_t *opts, int curr_arg, int argc, const char **argv)
+int parse_pattern_len(pattern_len_info_t *plen_info, int curr_arg, int argc, const char **argv)
 {
-    parse_next_int_parameter(OPTION_LONG_PATTERN_LEN, &(opts->pattern_min_len), curr_arg, argc, argv);
+    parse_next_int_parameter(OPTION_LONG_PATTERN_LEN, &(plen_info->pattern_min_len), curr_arg, argc, argv);
 
     // If we have a second parameter at curr_arg + 2, this is the maximum
     if (curr_arg + 2 < argc && !is_command_option(argv[curr_arg + 2]))
     {
-        parse_next_int_parameter(OPTION_LONG_PATTERN_LEN, &(opts->pattern_max_len), curr_arg + 1, argc, argv);
-        if (opts->pattern_max_len < opts->pattern_min_len)
+        parse_next_int_parameter(OPTION_LONG_PATTERN_LEN, &(plen_info->pattern_max_len), curr_arg + 1, argc, argv);
+        if (plen_info->pattern_max_len < plen_info->pattern_min_len)
         {
-            error_and_exit(ERROR_MAX_LESS_THAN_MIN, ERROR_HEADER, opts->pattern_max_len,
-                           OPTION_LONG_PATTERN_LEN, opts->pattern_min_len, ERROR_FOOTER);
+            error_and_exit(ERROR_MAX_LESS_THAN_MIN, ERROR_HEADER, plen_info->pattern_max_len,
+                           OPTION_LONG_PATTERN_LEN, plen_info->pattern_min_len, ERROR_FOOTER);
         }
         return 2;
     }
     else // only one parameter provided - set the max to the min - just a single pattern length.
     {
-        opts->pattern_max_len = opts->pattern_min_len;
+        plen_info->pattern_max_len = plen_info->pattern_min_len;
         return 1;
-    }
-}
-
-/*
- * Parses the type of increment to use for pattern lengths.
- */
-void parse_increment_type(run_command_opts_t *opts, const char *param)
-{
-    char itype = param[0];
-    if (itype == '+' || itype == '*')
-    {
-        opts->increment_operator = itype;
-    }
-    else
-    {
-        error_and_exit(ERROR_INCREMENT_PLUS_OR_TIMES, ERROR_HEADER, OPTION_LONG_PATTERN_LEN, param, ERROR_FOOTER);
     }
 }
 
@@ -269,7 +275,7 @@ void parse_increment_type(run_command_opts_t *opts, const char *param)
  * A pattern length is guaranteed to increase by at least one over the current value, no matter what the increment settings.
  * Returns the number of parameters parsed.
  */
-int parse_increment(run_command_opts_t *opts, int curr_arg, int argc, const char **argv)
+int parse_increment(pattern_len_info_t *opts, int curr_arg, int argc, const char **argv)
 {
     check_end_of_params(curr_arg, argc, OPTION_LONG_INCREMENT);
     const char *param = argv[curr_arg + 1];
@@ -294,7 +300,7 @@ int parse_increment(run_command_opts_t *opts, int curr_arg, int argc, const char
     }
     else
     {
-        error_and_exit(ERROR_INCREMENT_PLUS_OR_TIMES, ERROR_HEADER, OPTION_LONG_PATTERN_LEN, param, ERROR_FOOTER);
+        error_and_exit(ERROR_INCREMENT_PLUS_OR_TIMES, ERROR_HEADER, OPTION_LONG_INCREMENT, param, ERROR_FOOTER);
     }
 
     int min_len = opts->increment_operator == '+' ? 1 : 2;
@@ -373,8 +379,8 @@ int parse_pattern(run_command_opts_t *opts, int curr_arg, int argc, const char *
     check_end_of_params(curr_arg + 1, argc, OPTION_LONG_PATTERN);
 
     opts->pattern = argv[curr_arg + 1];
-    opts->pattern_min_len = strlen(opts->pattern);
-    opts->pattern_max_len = opts->pattern_min_len;
+    opts->pattern_info.pattern_min_len = strlen(opts->pattern);
+    opts->pattern_info.pattern_max_len = opts->pattern_info.pattern_min_len;
 
     return 1;
 }
@@ -410,17 +416,17 @@ int parse_flag(run_command_opts_t *opts, int curr_arg, int argc, const char **ar
     }
     else if (matches_option(argv[curr_arg], FLAG_SHORT_PATTERN_LENGTHS_SHORT, FLAG_LONG_PATTERN_LENGTHS_SHORT))
     {
-        opts->pattern_min_len = 2;
-        opts->pattern_max_len = 32;
-        opts->increment_operator = '+';
-        opts->increment_by = 2;
+        opts->pattern_info.pattern_min_len = 2;
+        opts->pattern_info.pattern_max_len = 32;
+        opts->pattern_info.increment_operator = '+';
+        opts->pattern_info.increment_by = 2;
     }
     else if (matches_option(argv[curr_arg], FLAG_SHORT_PATTERN_LENGTHS_VERY_SHORT, FLAG_LONG_PATTERN_LENGTHS_VERY_SHORT))
     {
-        opts->pattern_min_len = 1;
-        opts->pattern_max_len = 16;
-        opts->increment_operator = '+';
-        opts->increment_by = 1;
+        opts->pattern_info.pattern_min_len = 1;
+        opts->pattern_info.pattern_max_len = 16;
+        opts->pattern_info.increment_operator = '+';
+        opts->pattern_info.increment_by = 1;
     }
     else if (matches_option(argv[curr_arg], FLAG_SHORT_FILL_BUFFER, FLAG_LONG_FILL_BUFFER))
     {
@@ -439,7 +445,7 @@ int parse_flag(run_command_opts_t *opts, int curr_arg, int argc, const char **ar
 }
 
 /*
- * Parses the named set test command.
+ * Parses the named set option for the test command.
  * Returns the number of parameters parsed.
  */
 int parse_test_use_named_set(test_command_opts_t *opts, const int curr_arg, const int argc, const char **argv)
@@ -451,6 +457,24 @@ int parse_test_use_named_set(test_command_opts_t *opts, const int curr_arg, cons
     opts->algo_source = NAMED_SET_ALGOS;
 
     return 1;
+}
+
+/*
+ * Parses increment parameters for the test command, and sets the length defaults if not already set.
+ * Returns the number of parameters parsed.
+ */
+int parse_test_increment(pattern_len_info_t *pattern_info, int curr_arg, int argc, const char **argv)
+{
+    int params_parsed = parse_increment(pattern_info, curr_arg, argc, argv);
+
+    // If we specified an increment but haven't yet specified any pattern lengths, set the default min max values.
+    if (pattern_info->pattern_min_len == 0)
+    {
+        pattern_info->pattern_min_len = TEST_PATTERN_MIN_LEN;
+        pattern_info->pattern_max_len = TEST_PATTERN_MAX_LEN;
+    }
+
+    return params_parsed;
 }
 
 /*
@@ -507,11 +531,11 @@ void parse_run_args(int argc, const char **argv, smart_subcommand_t *subcommand)
         }
         else if (matches_option(param, OPTION_SHORT_PATTERN_LEN, OPTION_LONG_PATTERN_LEN))
         {
-            curr_arg += parse_pattern_len(opts, curr_arg, argc, argv);
+            curr_arg += parse_pattern_len(&(opts->pattern_info), curr_arg, argc, argv);
         }
         else if (matches_option(param, OPTION_SHORT_INCREMENT, OPTION_LONG_INCREMENT))
         {
-            curr_arg += parse_increment(opts, curr_arg, argc, argv);
+            curr_arg += parse_increment(&(opts->pattern_info), curr_arg, argc, argv);
         }
         else if (matches_option(param, OPTION_SHORT_SEED, OPTION_LONG_SEED))
         {
@@ -538,6 +562,8 @@ void parse_run_args(int argc, const char **argv, smart_subcommand_t *subcommand)
             parse_run_algo_name(opts, curr_arg, argv);
         }
     }
+
+    check_num_pattern_lengths(&(opts->pattern_info));
 
     if (opts->data_source == DATA_SOURCE_NOT_DEFINED)
         error_and_exit(ERROR_NO_DATA_SOURCE_DEFINED,
@@ -571,6 +597,14 @@ void parse_test_args(int argc, const char **argv, smart_subcommand_t *subcommand
         {
             curr_arg += parse_test_use_named_set(opts, curr_arg, argc, argv);
         }
+        else if (matches_option(param, OPTION_SHORT_PATTERN_LEN, OPTION_LONG_PATTERN_LEN))
+        {
+            curr_arg += parse_pattern_len(&(opts->pattern_info), curr_arg, argc, argv);
+        }
+        else if (matches_option(param, OPTION_SHORT_INCREMENT, OPTION_LONG_INCREMENT))
+        {
+            curr_arg += parse_test_increment(&(opts->pattern_info), curr_arg, argc, argv);
+        }
         else if (matches_option(param, OPTION_SHORT_SEED, OPTION_LONG_SEED))
         {
             curr_arg += parse_seed(&(opts->random_seed), curr_arg, argc, argv);
@@ -602,6 +636,8 @@ void parse_test_args(int argc, const char **argv, smart_subcommand_t *subcommand
     {
         error_and_exit(ERROR_NO_ALGORITHMS_DEFINED, ERROR_HEADER, ERROR_FOOTER);
     }
+
+    check_num_pattern_lengths(&(opts->pattern_info));
 
     opts->num_algo_names = num_algo_names;
 

--- a/src/run.h
+++ b/src/run.h
@@ -520,52 +520,6 @@ int benchmark_algos_with_patterns(algo_results_t *results, const run_command_opt
 }
 
 /*
- * Returns the next pattern length given the pattern length increment options and the current length.
- * Guarantees that the next pattern length will be at least one greater than the current length.
- */
-int next_pattern_length(const run_command_opts_t *opts, int current_length)
-{
-    int next_length = current_length;
-    if (opts->increment_operator == '*')
-    {
-        next_length *= opts->increment_by;
-    }
-    else if (opts->increment_operator == '+')
-    {
-        next_length += opts->increment_by;
-    }
-    else
-    {
-        error_and_exit("Unknown pattern length increment operator was set: %c", opts->increment_operator);
-    }
-
-    if (next_length <= current_length)
-    {
-        next_length = current_length + 1;
-    }
-
-    return next_length;
-}
-
-/*
- * Returns the number of different pattern lengths to be benchmarked.
- */
-int get_num_pattern_lengths(const run_command_opts_t *opts)
-{
-    if (opts->pattern != NULL) // If the pattern was supplied by the user, we only have one pattern to use.
-        return 1;
-
-    int num_patterns = 0;
-    int value = opts->pattern_min_len;
-    while (value <= opts->pattern_max_len && num_patterns <= NUM_PATTERNS_MAX)
-    {
-        value = next_pattern_length(opts, value);
-        num_patterns++;
-    }
-    return num_patterns;
-}
-
-/*
  * Computes information about the size of the alphabet contained in character frequency table freq, and gives
  * both the number of unique characters, and the maximum character code it contains.
  */
@@ -654,22 +608,46 @@ int get_text(const smart_config_t *smart_config, run_command_opts_t *opts, unsig
 }
 
 /*
+ * Returns the number of different pattern lengths to benchmark.
+ * If the user has supplied a pattern, there is only one.
+ * Otherwise, the pattern lengths are defined by the pattern length info.
+ */
+int get_num_patterns(const run_command_opts_t *opts)
+{
+    int num_pattern_lengths = 0;
+
+    // If the user supplies a pattern, we just have one, otherwise get the pattern lengths to use.
+    if (opts->pattern == NULL)
+    {
+        num_pattern_lengths = 1;
+        info("Benchmarking with a user supplied pattern of length %d.", opts->pattern_info.pattern_min_len);
+    }
+    else
+    {
+        num_pattern_lengths = get_num_pattern_lengths(&(opts->pattern_info));
+        info("Benchmarking with %d pattern lengths, from %d to %d, incrementing by %c %d.", num_pattern_lengths,
+             opts->pattern_info.pattern_min_len, opts->pattern_info.pattern_max_len,
+             opts->pattern_info.increment_operator, opts->pattern_info.increment_by);
+    }
+
+    return num_pattern_lengths;
+}
+
+/*
  * Benchmarks all algorithms over a text T for all pattern lengths.
  */
 int benchmark_algorithms_with_text(const run_command_opts_t *opts, unsigned char *T, int n, const algo_info_t *algorithms)
 {
-
-    int num_pattern_lengths = get_num_pattern_lengths(opts);
-    info("Benchmarking with %d pattern lengths, from %d to %d, incrementing by %c %d.", num_pattern_lengths,
-         opts->pattern_min_len, opts->pattern_max_len, opts->increment_operator, opts->increment_by);
+    int num_pattern_lengths = get_num_patterns(opts);
 
     benchmark_results_t results[num_pattern_lengths];
     unsigned char *pattern_list[opts->num_runs];
 
     allocate_benchmark_results(results, num_pattern_lengths, algorithms->num_algos, opts->num_runs);
-    allocate_pattern_matrix(pattern_list, opts->num_runs, opts->pattern_max_len);
+    allocate_pattern_matrix(pattern_list, opts->num_runs, opts->pattern_info.pattern_max_len);
 
-    for (int m = opts->pattern_min_len, pattern_idx = 0; m <= opts->pattern_max_len; m = next_pattern_length(opts, m), pattern_idx++)
+    for (int m = opts->pattern_info.pattern_min_len, pattern_idx = 0; m <= opts->pattern_info.pattern_max_len;
+             m = next_pattern_length(&(opts->pattern_info), m), pattern_idx++)
     {
         gen_patterns(opts, pattern_list, m, T, n, opts->num_runs);
         results[pattern_idx].pattern_length = m;
@@ -703,7 +681,7 @@ void print_search_and_preprocessing_time_info(run_command_opts_t *opts)
 void load_and_run_benchmarks(const smart_config_t *smart_config, run_command_opts_t *opts, algo_info_t *algorithms)
 {
     // Get the text to search in.
-    unsigned char *T = (unsigned char *)malloc(get_text_buffer_size(opts->text_size, opts->pattern_max_len));
+    unsigned char *T = (unsigned char *)malloc(get_text_buffer_size(opts->text_size, opts->pattern_info.pattern_max_len));
     int n = get_text(smart_config, opts, T);
     print_text_info(T, n);
 
@@ -777,6 +755,34 @@ void get_algorithms_to_benchmark(const smart_config_t *smart_config, run_command
 }
 
 /*
+ * Prints an appropriate error message if no algorithms can be found to run with.
+ */
+void print_algorithm_missing_error_and_exit(const smart_config_t *smart_config, run_command_opts_t *opts)
+{
+    switch (opts->algo_source)
+    {
+        case ALGO_REGEXES:
+        {
+            error_and_exit("No algorithms matched the ones specified on the command line.");
+        }
+        case ALL_ALGOS:
+        {
+            error_and_exit("No algorithms could be located on the algorithm search paths.");
+        }
+        case NAMED_SET_ALGOS:
+        case SELECTED_ALGOS:
+        {
+            error_and_exit("No algorithms were found to benchmark in %s/%s", smart_config->smart_config_dir,
+                           opts->algo_filename);
+        }
+        default:
+        {
+            error_and_exit("Unknown algorithm source %d", opts->algo_source);
+        }
+    }
+}
+
+/*
  * Executes the benchmark with the given benchmark options.
  */
 void run_benchmark(const smart_config_t *smart_config, run_command_opts_t *opts)
@@ -791,9 +797,7 @@ void run_benchmark(const smart_config_t *smart_config, run_command_opts_t *opts)
     }
     else
     {
-        // TODO: fix - we can load algorithms from command line now as well as named sets - this error message is not always true anymore.
-        error_and_exit("No algorithms were found to benchmark in %s/%s", smart_config->smart_config_dir,
-                       opts->algo_filename);
+        print_algorithm_missing_error_and_exit(smart_config, opts);
     }
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -428,7 +428,7 @@ void print_file_and_access(const char *header, const char *path, const char *fil
  */
 void print_help_line(const char *description, const char *short_option, const char *long_option, const char *params)
 {
-    info("%-6s %-18s %-8s %s", short_option, long_option, params, description);
+    info("%-8s %-18s %-8s %s", short_option, long_option, params, description);
 }
 
 /*


### PR DESCRIPTION
This PR gives better control over pattern lengths to benchmark and test.

**Single param for `-plen`**
If you only want to use a single pattern length, you can just specify one number instead of two.

**Increment command**
A new command `-inc` takes parameter [`+` | `*`] followed by a digit to add or multiply by.  For example:
`smart run -text genome -plen 2 64 -inc +4`
`smart test wfr.* -plen 1 1024 -inc *3`

**Short and Vshort options restored**
The `-short` and `-vshort` options have been restored.  Short defines 2 .. 32 inc +2, and VShort defines 1 .. 16 inc +1.

**Specify pattern lengths for test as well**
When running tests on the algorithms, I wanted to be able to ensure I tested particular pattern lengths.  So I have added the `-plen` and `-inc` commands to test as well.  If you use them, it still runs all the normal fixed length tests and so on, but random patterns will have the range of pattern lengths you have specified.

