### PR TITLE
Fix test allocations

### DIFF
--- a/src/commands.h
+++ b/src/commands.h
@@ -423,6 +423,8 @@ static char *const OPTION_SHORT_DEBUG = "-d";
 static char *const OPTION_LONG_DEBUG = "--debug";
 static char *const OPTION_SHORT_QUICK_TESTS = "-q";
 static char *const OPTION_LONG_QUICK_TESTS = "--quick";
+static char *const OPTION_SHORT_FAIL_ONLY = "-fo";
+static char *const OPTION_LONG_FAIL_ONLY = "--fail-only";
 
 /*
  * Options for the test subcommand.
@@ -437,6 +439,7 @@ typedef struct test_command_opts
     pattern_len_info_t pattern_info;               // Info about what pattern sizes to test random patterns with.
     int debug;                                     // If set will re-call a failing search function with the failing parameters.
     int quick;                                     // Whether to run quick tests.
+    int fail_only;                                 // Whether to only report failures in the test output.
 } test_command_opts_t;
 
 /*
@@ -452,6 +455,7 @@ void init_test_command_opts(test_command_opts_t *opts)
     opts->random_seed  = time(NULL);   // default is random seed set by the current time, unless -seed option is specified.
     opts->debug = 0;
     opts->quick = 0;
+    opts->fail_only = 0;
     opts->pattern_info.pattern_min_len = 0;            // Only set to a real operator if we are specifying pattern lengths for test.
     opts->pattern_info.pattern_max_len = 0;            // Only set to a real operator if we are specifying pattern lengths for test.
     opts->pattern_info.increment_operator = INCREMENT_MULTIPLY_OPERATOR;
@@ -481,6 +485,7 @@ void print_test_usage_and_exit(const char *command)
     print_help_line("To multiply by a fixed amount V, use operator *", "", "", "* V");
     print_help_line("Sets the random seed to integer S, ensuring tests can be precisely repeated.", OPTION_SHORT_SEED, OPTION_LONG_SEED, "S");
     print_help_line("Runs tests faster by testing less exhaustively.", OPTION_SHORT_QUICK_TESTS, OPTION_LONG_QUICK_TESTS, "");
+    print_help_line("Report only failures in the test output.", OPTION_SHORT_FAIL_ONLY, OPTION_LONG_FAIL_ONLY, "");
     print_help_line("Useful to get fast feedback, but all tests should pass before benchmarking against other algorithms.", "", "", "");
     print_help_line("Re-runs a failing search - put a breakpoint on debug_search() in test.h", OPTION_SHORT_DEBUG, OPTION_LONG_DEBUG, "");
     print_help_line("Gives this help list.", OPTION_SHORT_HELP, OPTION_LONG_HELP, "");

--- a/src/defines.h
+++ b/src/defines.h
@@ -77,6 +77,10 @@
 #define TEST_PATTERN_MIN_LEN 1            // min length of random pattern to use when testing.
 #define TEST_PATTERN_MAX_LEN 2048         // max length of random patterns to use when testing.
 #define MAX_FAILURE_MESSAGES 32           // max number of failure messages to record.
+#define TEST_ITERATIONS 12                // number of iterations of each test for standard tests.
+#define TEST_QUICK_ITERATIONS 2           // number of iterations of each test for quick tests.
+#define TEST_SHORT_PAT_LEN 16             // max length X of 1..X short pattern lengths tested at end and start.
+
 /*
  * Console output formatting defines.
  */

--- a/src/defines.h
+++ b/src/defines.h
@@ -7,6 +7,7 @@
  */
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define WITHIN(v, l, u) (MAX((l), MIN((u), (v))))  // Returns a value between a lower bound l and upper bound u inclusive, given value v.
 
 /*
  * Basic constants.
@@ -32,7 +33,7 @@
 #define NUM_PATTERNS_MAX 100              // maximum number of different pattern lengths to benchmark at one time.
 #define MAX_LINE_LEN 128                  // max length of line to output to console.
 #define STR_BUF 256                       // general strings with a bit of space to spare - parameters, filenames, etc.
-#define NUM_PATTERNS_AT_END_OF_TEXT 3     // Number of pattern-lengths to add to the text buffer so algorithms that write
+#define NUM_PATTERNS_AT_END_OF_TEXT 2     // Number of pattern-lengths to add to the text buffer so algorithms that write
                                           // to the end of the text (e.g. sentinel guard) do not cause buffer overflows.
 #define TEXT_SIZE_PADDING 256             // extra memory allocated to end of text buffer for safety in case algorithms modify too much text.
 
@@ -58,14 +59,18 @@
 #define SEARCH_PATH_DELIMITER ":"                              // delimiter used to separate search paths specified in environment variables.
 
 /*
+ * Pattern length increment control
+ */
+#define INCREMENT_MULTIPLY_OPERATOR '*'   // operator for multiply (default)
+#define INCREMENT_ADD_OPERATOR '+'        // operator for add.
+#define INCREMENT_BY 2                    // default pattern increment is to multiply by 2
+
+/*
  * Benchmarking defaults
  */
 #define TEXT_SIZE_DEFAULT MEGA_BYTE       // default size of text buffer for benchmarking
 #define PATTERN_MIN_LEN_DEFAULT 2         // default minimum size of pattern to benchmark.
 #define PATTERN_MAX_LEN_DEFAULT 4096      // default maximum size of pattern to benchmark.
-#define INCREMENT_MULTIPLY_OPERATOR '*'   // operator for multiply.
-#define INCREMENT_ADD_OPERATOR '+'        // operator for add.
-#define INCREMENT_BY 2                    // default pattern increment is to multiply by 2
 #define NUM_RUNS_DEFAULT 500              // default number of patterns of a given size to benchmark with.
 #define TIME_LIMIT_MILLIS_DEFAULT 300     // default time limit in milliseconds for a search to pass benchmarking.
 #define CPU_PIN_DEFAULT PIN_LAST_CPU      // default CPU pinning - can be [off | last | {digit}]
@@ -74,6 +79,8 @@
  * Test settings
  */
 #define TEST_TEXT_SIZE 8192               // size of text buffer for testing.
+#define TEST_TEXT_PRE_BUFFER 64           // space to allocate at the start of the test text buffer to prevent seg faults if algorithms read before start of text.
+                                          // IMPORTANT: this value must be word-aligned.  Some search algorithms require the text to start at a word boundary (e.g. SSEF).
 #define TEST_PATTERN_MIN_LEN 1            // min length of random pattern to use when testing.
 #define TEST_PATTERN_MAX_LEN 2048         // max length of random patterns to use when testing.
 #define MAX_FAILURE_MESSAGES 32           // max number of failure messages to record.

--- a/src/parser.h
+++ b/src/parser.h
@@ -632,6 +632,10 @@ void parse_test_args(int argc, const char **argv, smart_subcommand_t *subcommand
         {
             opts->quick = 1;
         }
+        else if (matches_option(param, OPTION_SHORT_FAIL_ONLY, OPTION_LONG_FAIL_ONLY))
+        {
+            opts->fail_only = 1;
+        }
         else if (matches_option(param, OPTION_SHORT_HELP, OPTION_LONG_HELP))
         {
             print_test_usage_and_exit(argv[0]);

--- a/src/test.h
+++ b/src/test.h
@@ -21,8 +21,6 @@ typedef struct test_results_info
     int num_passed;
     int last_expected_count;
     int last_actual_count;
-    int buffer_overflow;
-    int overwrites_text;
     int num_failure_messages;
     char failure_messages[MAX_FAILURE_MESSAGES][STR_BUF];
 } test_results_info_t;
@@ -40,8 +38,6 @@ void init_test_results(test_results_info_t *results, const test_command_opts_t *
     results->opts = opts;
     results->last_expected_count = -1; // initialise to an invalid value.
     results->last_actual_count = -2;   // initialise to a *different* invalid value.
-    results->buffer_overflow = 0;
-    results->overwrites_text = 0;
     results->num_failure_messages = 0;
     memset(results->failure_messages, 0, MAX_FAILURE_MESSAGES * STR_BUF);
     memset(results->test_message, 0, STR_BUF);
@@ -727,7 +723,6 @@ int run_buffer_overflow_tests(test_results_info_t *test_results)
         {
             add_failure_message(test_results, "Overwrote the search text at position %s in a text of size %d",
                                 i, TEST_TEXT_SIZE);
-            test_results->overwrites_text = 1;
             overflow_test_passed = 0; // overwriting the text itself is a major failure.
 
             debug_search(test_results, pattern, TEST_PATTERN_MAX_LEN, search_data, TEST_TEXT_SIZE);
@@ -741,7 +736,6 @@ int run_buffer_overflow_tests(test_results_info_t *test_results)
         if (copy_data[i] != search_data[i])
         {
             add_failure_message(test_results, "Overwrote the buffer beyond the supported buffer size.");
-            test_results->buffer_overflow = 1;
             overflow_test_passed = 0; // overwriting text beyond the max buffer size supported is a major failure.
 
             debug_search(test_results, pattern, TEST_PATTERN_MAX_LEN, search_data, TEST_TEXT_SIZE);
@@ -779,29 +773,15 @@ void print_failure_result(test_results_info_t *test_results)
         printf("\r\tTested  %-*s [--]      No tests executed.        (%d/%d)    \n", ALGO_NAME_LEN, test_results->algo_name,
                test_results->num_passed, test_results->num_tests);
     }
-    else if (test_results->overwrites_text)
-    {
-        printf("\r\tTested  %-*s [ERROR]   Overwrote text.          (%d/%d)    \n", ALGO_NAME_LEN, test_results->algo_name,
-               test_results->num_passed, test_results->num_tests);
-    }
-    else if (test_results->buffer_overflow)
-    {
-        printf("\r\tTested  %-*s [ERROR]   Buffer overflow.          (%d/%d)    \n", ALGO_NAME_LEN, test_results->algo_name,
-               test_results->num_passed, test_results->num_tests);
-    }
     else if (test_results->num_passed == 0)
     {
-        printf("\r\tTested  %-*s [FAIL]    None passed               (%d/%d)    \n", ALGO_NAME_LEN, test_results->algo_name,
+        printf("\r\tTested  %-*s [FAIL]    All failed                (%d/%d)    \n", ALGO_NAME_LEN, test_results->algo_name,
                test_results->num_passed, test_results->num_tests);
     }
     else if (test_results->num_passed < test_results->num_tests)
     {
         printf("\r\tTested  %-*s [FAIL]    Some failed               (%d/%d)    \n", ALGO_NAME_LEN, test_results->algo_name,
                test_results->num_passed, test_results->num_tests);
-    }
-    else
-    {
-        printf("\n");
     }
 }
 

--- a/src/test.h
+++ b/src/test.h
@@ -168,7 +168,7 @@ void test_fixed_string(char *pattern, char *text, test_results_info_t *test_resu
     // Copy pattern and search text to heap memory, and zero out remaining text.
     memcpy(pattern_data, pattern, m);
     memcpy(text_data, text, n);
-    memset(text_data + m, 0, buffer_size - m);
+    memset(text_data + n, 0, buffer_size - n);
 
     if (!test_algo(pattern_data, m, text_data, n, test_results))
     {

--- a/src/test.h
+++ b/src/test.h
@@ -806,6 +806,16 @@ void print_failure_result(test_results_info_t *test_results)
 }
 
 /*
+ * Erases anything on the current line by issuing a CR, printing a line length of spaces and then issuing a CR again.
+ */
+void clear_line()
+{
+    printf("\r");
+    for (int i = 0; i < MAX_LINE_LEN; i++) printf("%s", " ");
+    printf("\r");
+}
+
+/*
  * Prints the final results of testing an algo.
  */
 void print_test_results(test_results_info_t *test_results)
@@ -818,7 +828,7 @@ void print_test_results(test_results_info_t *test_results)
         }
         else
         {
-            printf("\r"); // continue on the same line for the next test - we passed.
+            clear_line();
         }
     }
     else if (test_results->num_passed == test_results->num_tests)
@@ -855,6 +865,7 @@ void test_algos(const test_command_opts_t *opts, const algo_info_t *algorithms)
         unsigned char *T = (unsigned char *)malloc(buffer_size);
         memset(T, 0, buffer_size);
 
+        int num_failed = 0;
         for (int algo_no = 0; algo_no < algorithms->num_algos; algo_no++)
         {
             test_results_info_t test_results;
@@ -870,8 +881,11 @@ void test_algos(const test_command_opts_t *opts, const algo_info_t *algorithms)
             }
 
             print_test_results(&test_results);
+            if (test_results.num_failure_messages > 0) num_failed++;
         }
 
+        info("");
+        info("Tested %d algorithms with %d failures.\n", algorithms->num_algos, num_failed);
         free(T);
     }
     else


### PR DESCRIPTION
- Allocate test patterns and text on heap to avoid any stack corruption if algos have bug.
- Add test for partial pattern at start (takes a pattern and copies bytes 1..m-1 to the start of the text
- Add test for pattern overflowing end (takes a pattern and copies it to the end of the text so the last character of the pattern is past the end of the text buffer).
