### PR TITLE
FIX SBNDM-W2 W4 and W6

### DIFF
--- a/src/algos/sbndm-w2.c
+++ b/src/algos/sbndm-w2.c
@@ -51,9 +51,8 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
    int plen = m;
    if(m>32) m=32;
    int m1 = m-1;
-   int mp1 =  m+1;   
 
-   /* Pre processing*/ 
+   /* Pre processing*/
    BEGIN_PREPROCESSING
    for(i=0; i<SIGMA; i++) B[i]=W[i]=0;
    j=1;
@@ -65,7 +64,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
       f >>= 1;
    }
 
-	for (i=0;i<SIGMA;i++)   hbcr[i]=hbcl[i]=2*m;
+   for (i=0;i<SIGMA;i++)   hbcr[i]=hbcl[i]=2*m;
    for (i=0;i<m;i++) {
        hbcr[x[i]]=(2*m)-i-1;
        hbcl[x[m-1-i]]=(2*m)-i-1;
@@ -74,7 +73,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 
    /* Searching phase */
    BEGIN_SEARCHING
-   s1=m1; s2=n-m; count=0;
+   s1=m1; s2=n-plen; count=0;
    while (s1 <= s2+m1){
          while ((d = (B[y[s1]]|W[y[s2]])) == 0) {
          s1 += hbcr[y[s1+m]];

--- a/src/algos/sbndm-w4.c
+++ b/src/algos/sbndm-w4.c
@@ -51,7 +51,6 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
    int plen = m;
    if(m>32) m=32;
    int m1 = m-1;
-   int mp1 =  m+1;   
 
    /* Pre processing */
    BEGIN_PREPROCESSING
@@ -75,7 +74,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
    /* Searching phase */
    BEGIN_SEARCHING
    int q = n/2;
-   s1=m-1; s2=q-m; s3 = q; s4=n-m; count=0;
+   s1=m-1; s2=q-m; s3 = q; s4=n-plen; count=0;
    while (s1<=s2+m1 || s3<=s4+m1){
          while ((d = (B[y[s1]]|W[y[s2]]|B[y[s3]]|W[y[s4]])) == 0) {
          s1 += hbcr[y[s1+m]];

--- a/src/algos/sbndm-w6.c
+++ b/src/algos/sbndm-w6.c
@@ -75,7 +75,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
    /* Searching phase */
    BEGIN_SEARCHING
    int q = n/3;
-   s1=m-1; s2=q-m; s3 = q; s4=2*q-m; s5=2*q; s6=n-m; count=0;
+   s1=m-1; s2=q-m; s3 = q; s4=2*q-m; s5=2*q; s6=n-plen; count=0;
    while (s1<=s2+m1 || s3<=s4+m1 || s5<=s6+m1){
          while ((d = (B[y[s1]]|W[y[s2]]|B[y[s3]]|W[y[s4]]|B[y[s5]]|W[y[s6]])) == 0) {
          s1 += hbcr[y[s1+m]];


### PR DESCRIPTION
  * Similar to fix for the other BNDM algorithm, the search function was not taking account of the full pattern length.
  * The last valid position in the text is not n-m, it is n-plen (as m is adjusted before)
  * Simple valid bounds calculation error.