### PR TITLE
FIX BSDMx

### DIFF
--- a/src/algos/bsdm2.c
+++ b/src/algos/bsdm2.c
@@ -80,7 +80,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if((j-offset<=n-m) && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }

--- a/src/algos/bsdm3.c
+++ b/src/algos/bsdm3.c
@@ -81,7 +81,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if(j-offset<=n-m && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }

--- a/src/algos/bsdm4.c
+++ b/src/algos/bsdm4.c
@@ -81,7 +81,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if(j-offset<=n-m && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }

--- a/src/algos/bsdm5.c
+++ b/src/algos/bsdm5.c
@@ -81,7 +81,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if(j-offset<=n-m && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }

--- a/src/algos/bsdm6.c
+++ b/src/algos/bsdm6.c
@@ -82,7 +82,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if(j-offset<=n-m && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }

--- a/src/algos/bsdm7.c
+++ b/src/algos/bsdm7.c
@@ -81,7 +81,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if(j-offset<=n-m && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }

--- a/src/algos/bsdm8.c
+++ b/src/algos/bsdm8.c
@@ -81,7 +81,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
 	    while(k<=i && xst[i-k]==y[j-k]) k++;
 	    if(k>i) {
 	    	if(k==len) {
-	    		if(!memcmp(x,y+j-offset,m)) if(j-offset<=n-m) count++;
+	    		if(j-offset<=n-m && j-offset >= 0 && !memcmp(x,y+j-offset,m)) count++;
 	    	}
 	    	else j-=k;
 	    }


### PR DESCRIPTION
  * These algorithms were occasionally trying to validate a pattern before the text starts.
  * Simple valid bounds calculation error.
  * Fix is to only test for a match if the position is >= 0 as well as <= n-m.