### PR TITLE
Use sample standard deviation.

### DIFF
--- a/src/run.h
+++ b/src/run.h
@@ -238,15 +238,21 @@ double compute_median_of_sorted_array(const double *T, int n)
 }
 
 /*
- * Computes and returns the standard deviation given a mean average, and a list of search times of size n.
+ * Computes and returns the sample standard deviation given a mean average, and a list of search times of size n.
+ *
+ * Sample standard deviation differs from population standard deviation, by dividing by one less than the number of
+ * samples.  This biases the sample standard deviation to be slightly bigger, to account for likely wider variation
+ * in the population as a whole.
+ *
+ * See: https://www.statology.org/population-vs-sample-standard-deviation/
  */
 double compute_std(double avg, double *T, int n)
 {
     double std = 0.0;
     for (int i = 0; i < n; i++)
         std += pow(avg - T[i], 2.0);
-
-    return sqrt(std / n);
+    int sample_divisor = n > 1 ? n - 1 : 1;
+    return sqrt(std / sample_divisor);
 }
 
 /*

--- a/src/run.h
+++ b/src/run.h
@@ -251,7 +251,7 @@ double compute_std(double avg, double *T, int n)
     double std = 0.0;
     for (int i = 0; i < n; i++)
         std += pow(avg - T[i], 2.0);
-    int sample_divisor = MAX(1, n);
+    int sample_divisor = MAX(1, n - 1);
     return sqrt(std / sample_divisor);
 }
 

--- a/src/run.h
+++ b/src/run.h
@@ -251,7 +251,7 @@ double compute_std(double avg, double *T, int n)
     double std = 0.0;
     for (int i = 0; i < n; i++)
         std += pow(avg - T[i], 2.0);
-    int sample_divisor = n > 1 ? n - 1 : 1;
+    int sample_divisor = MAX(1, n);
     return sqrt(std / sample_divisor);
 }
 


### PR DESCRIPTION
  * We were using the population standard deviation, rather than the sample standard deviation.
  * Since variability in a population is almost certainly a bit bigger than what was captured in a sample, we divide by one less than the number of samples, rather than the total number of samples.
  * This biases the standard deviation to be slightly bigger which tends to give better estimates for the population as a whole.