### PR TITLE
Minorfixes

### DIFF
--- a/src/bench_results.h
+++ b/src/bench_results.h
@@ -137,13 +137,14 @@ double compute_median(const double *T, int n)
     qsort(sorted, n, sizeof(double), double_compare);
 
     // if the list of doubles  has an even number of elements:
+
     if (n % 2 == 0)
     {
-        return (sorted[n / 2] + sorted[n / 2 + 1]) / 2; // return mean of n/2 and n/2+1 elements.
+        return (sorted[n / 2 - 1] + sorted[n / 2]) / 2; // return mean of n/2 and n/2+1 elements.
     }
     else
     {
-        return sorted[(n + 1) / 2]; // return the element in the middle of the sorted array.
+        return sorted[(n + 1) / 2 - 1]; // return the element in the middle of the sorted array.
     }
 }
 

--- a/src/bench_results.h
+++ b/src/bench_results.h
@@ -140,7 +140,7 @@ double compute_median(const double *T, int n)
 
     if (n % 2 == 0)
     {
-        return (sorted[n / 2 - 1] + sorted[n / 2]) / 2; // return mean of n/2 and n/2+1 elements.
+        return (sorted[n / 2 - 1] + sorted[n / 2]) / 2; // return mean of n/2-1 and n/2 elements.
     }
     else
     {

--- a/src/run.h
+++ b/src/run.h
@@ -81,16 +81,15 @@ enum measurement_status run_algo(unsigned char **pattern_list, int m,
             cpu_perf_end(&perf_events, &(results->measurements.cpu_stats[k]));
         }
 
-        //TODO: for user supplied patterns and/or data, it is possible to have zero matches and not be an error.
-        if (occur == 0 || occur == ERROR_SEARCHING)
-        {
-            status = ERROR;
-            break; // there must be at least one match for each text and pattern (patterns are extracted from text).
-        }
-
         if (occur == INFO_CANNOT_SEARCH) {
             status = CANNOT_SEARCH; // negative value returned from search means it cannot search this pattern (e.g. it is too short)
             break;
+        }
+
+        if (occur == ERROR_SEARCHING)
+        {
+            status = ERROR;
+            break; // there must be at least one match for each text and pattern (patterns are extracted from text).
         }
 
         results->occurrence_count += occur;

--- a/src/run.h
+++ b/src/run.h
@@ -150,7 +150,7 @@ void get_results_info(char output_line[MAX_LINE_LEN], const run_command_opts_t *
 
         if (opts->pre)
         {
-            snprintf(output_line, MAX_LINE_LEN, "\t(%.*f - %.*f, %.*f, %.*f) + (%.*f - %.*f, %.*f ± %.*f, %.*f) ms\t   %s\t%s",
+            snprintf(output_line, MAX_LINE_LEN, "\t(%.*f - %.*f,  %.*f,  %.*f) + (%.*f - %.*f,  %.*f ± %.*f,  %.*f) ms\t   %s\t%s",
                      opts->precision, results->statistics.min_pre_time,
                      opts->precision, results->statistics.max_pre_time,
                      opts->precision, results->statistics.mean_pre_time,
@@ -164,7 +164,7 @@ void get_results_info(char output_line[MAX_LINE_LEN], const run_command_opts_t *
         }
         else
         {
-            snprintf(output_line, MAX_LINE_LEN, "\t%.*f - %.*f, %.*f ± %.*f, %.*f ms\t   %s\t%s",
+            snprintf(output_line, MAX_LINE_LEN, "\t%.*f - %.*f,  %.*f ± %.*f,  %.*f ms\t   %s\t%s",
                      opts->precision, results->statistics.min_total_time,
                      opts->precision, results->statistics.max_total_time,
                      opts->precision, results->statistics.mean_total_time,
@@ -177,7 +177,7 @@ void get_results_info(char output_line[MAX_LINE_LEN], const run_command_opts_t *
     {
         if (opts->pre)
         {
-            snprintf(output_line, MAX_LINE_LEN, "\t(%.*f - %.*f, %.*f, %.*f) + (%.*f - %.*f, %.*f ± %.*f, %.*f) ms\t%s",
+            snprintf(output_line, MAX_LINE_LEN, "\t(%.*f - %.*f,  %.*f,  %.*f) + (%.*f - %.*f,  %.*f ± %.*f,  %.*f) ms\t%s",
                      opts->precision, results->statistics.min_pre_time,
                      opts->precision, results->statistics.max_pre_time,
                      opts->precision, results->statistics.mean_pre_time,
@@ -191,7 +191,7 @@ void get_results_info(char output_line[MAX_LINE_LEN], const run_command_opts_t *
         }
         else
         {
-            snprintf(output_line, MAX_LINE_LEN, "\t%.*f - %.*f, %.*f ± %.*f, %.*f ms\t%s",
+            snprintf(output_line, MAX_LINE_LEN, "\t%.*f - %.*f,  %.*f ± %.*f,  %.*f ms\t%s",
                      opts->precision, results->statistics.min_total_time,
                      opts->precision, results->statistics.max_total_time,
                      opts->precision, results->statistics.mean_total_time,
@@ -271,10 +271,10 @@ int benchmark_algos_with_patterns(algo_results_t *results, const run_command_opt
                                   unsigned char **pattern_list, int m, const algo_info_t *algorithms)
 {
     info("\n------------------------------------------------------------");
-    info("\tSearching for a set of %d patterns with length %d", opts->num_runs, m);
+    info("\tSearching for a set of %d patterns with length %d",opts->num_runs, m);
 
     const char *pre_header = opts->pre ? "(preprocessing) + (search): " : "";
-    info("\tTesting %d algorithms                   %smin - max, mean ± stddev, median", algorithms->num_algos, pre_header);
+    info("\tTesting %d algorithms                   %smin - max,  mean ± stddev,  median", algorithms->num_algos, pre_header);
 
     for (int algo = 0; algo < algorithms->num_algos; algo++)
     {


### PR DESCRIPTION
space out results a bit more.
allow searches for patterns that don't exist in the text.
also fix the median calculation - didn't take into account that the list is zero indexed.